### PR TITLE
Fixed delay to use AHB clock / 8 instead of CORE clk

### DIFF
--- a/src/delay.rs
+++ b/src/delay.rs
@@ -18,7 +18,7 @@ impl Delay {
     pub fn new(syst: SYST, clocks: &Clocks) -> Self {
         Delay {
             syst,
-            clk: clocks.core_clk,
+            clk: clocks.ahb_clk / 8,
         }
     }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -87,6 +87,14 @@ impl Div for Hertz {
     }
 }
 
+impl Div<u32> for Hertz {
+    type Output = Hertz;
+
+    fn div(self, other: u32) -> Self::Output {
+        Self(self.0 / other)
+    }
+}
+
 impl MicroSecond {
     pub fn cycles(self, clk: Hertz) -> u32 {
         assert!(self.0 > 0);


### PR DESCRIPTION
I noticed delays where off by a factor 8. This was because the delay function calculated it's time based off the core clock. The cortex system timer is actually connected to AHB clock with a prescaler of /8.