### PR TITLE
Use Delay implementation from cortex-m crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/stm32-rs/stm32g4xx-hal"
 version = "0.0.0"
 
 [dependencies]
-cortex-m = "0.6.1"
+cortex-m = "0.7.1"
 nb = "0.1.1"
 stm32g4 = "0.9.0"
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,91 +1,29 @@
-//! Delays
-use core::cmp;
-use cortex_m::peripheral::SYST;
-use hal::blocking::delay::{DelayMs, DelayUs};
-
-use crate::prelude::*;
 use crate::rcc::Clocks;
-use crate::time::{Hertz, MicroSecond};
+use crate::time::MicroSecond;
+pub use cortex_m::delay::*;
+use cortex_m::{peripheral::SYST, prelude::_embedded_hal_blocking_delay_DelayUs};
 
-/// System timer (SysTick) as a delay provider
-pub struct Delay {
-    clk: Hertz,
-    syst: SYST,
+pub trait SYSTDelayExt {
+    fn delay(self, clocks: &Clocks) -> Delay;
 }
 
-impl Delay {
-    /// Configures the system timer (SysTick) as a delay provider
-    pub fn new(syst: SYST, clocks: &Clocks) -> Self {
-        Delay {
-            syst,
-            clk: clocks.ahb_clk / 8,
-        }
-    }
-
-    pub fn delay<T>(&mut self, delay: T)
-    where
-        T: Into<MicroSecond>,
-    {
-        let mut cycles = delay.into().cycles(self.clk);
-        while cycles > 0 {
-            let reload = cmp::min(cycles, 0x00ff_ffff);
-            cycles -= reload;
-            self.syst.set_reload(reload);
-            self.syst.clear_current();
-            self.syst.enable_counter();
-            while !self.syst.has_wrapped() {}
-            self.syst.disable_counter();
-        }
-    }
-
-    /// Releases the system timer (SysTick) resource
-    pub fn release(self) -> SYST {
-        self.syst
-    }
-}
-
-impl DelayUs<u32> for Delay {
-    fn delay_us(&mut self, us: u32) {
-        self.delay(us.us())
-    }
-}
-
-impl DelayUs<u16> for Delay {
-    fn delay_us(&mut self, us: u16) {
-        self.delay_us(us as u32)
-    }
-}
-
-impl DelayUs<u8> for Delay {
-    fn delay_us(&mut self, us: u8) {
-        self.delay_us(us as u32)
-    }
-}
-
-impl DelayMs<u32> for Delay {
-    fn delay_ms(&mut self, ms: u32) {
-        self.delay_us(ms.saturating_mul(1_000));
-    }
-}
-
-impl DelayMs<u16> for Delay {
-    fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(ms as u32);
-    }
-}
-
-impl DelayMs<u8> for Delay {
-    fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(ms as u32);
+impl SYSTDelayExt for SYST {
+    fn delay(self, clocks: &Clocks) -> Delay {
+        Delay::new(self, clocks.ahb_clk.0)
     }
 }
 
 pub trait DelayExt {
-    fn delay(self, clocks: &Clocks) -> Delay;
+    fn delay<T>(&mut self, delay: T)
+    where
+        T: Into<MicroSecond>;
 }
 
-impl DelayExt for SYST {
-    fn delay(self, clocks: &Clocks) -> Delay {
-        Delay::new(self, clocks)
+impl DelayExt for Delay {
+    fn delay<T>(&mut self, delay: T)
+    where
+        T: Into<MicroSecond>,
+    {
+        self.delay_us(delay.into().0)
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -17,6 +17,7 @@ pub use hal::watchdog::WatchdogEnable as _;
 // pub use crate::comparator::ComparatorExt as _;
 // pub use crate::crc::CrcExt as _;
 pub use crate::delay::DelayExt as _;
+pub use crate::delay::SYSTDelayExt as _;
 // pub use crate::dma::CopyDma as _;
 // pub use crate::dma::ReadDma as _;
 // pub use crate::dma::WriteDma as _;


### PR DESCRIPTION
While working on other changes I noticed the latest `cortex-m` crate  got the Delay implementation that is tiny bit more  powerful than the current one in this crate. So I updated the dependency and removed most of Delay implementation, I left the `time` based function as a trait for the main `Delay`, and added them to `prelude`, not sure if that is the best approach so any comments highly welcome. 

The implementation from `cortex-m `crate uses the Core-provided clock
for the timer instead of the default External this gives 8 times better resolution.

Additionally the crate's implementation can handle much longer delays
as it uses 64 bit integer to calculate needed cycles for sleep.