### PR TITLE
Fix logging in the examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ cortex-m-rtfm = "0.5.1"
 cortex-m-semihosting = "0.3.5"
 panic-semihosting = "0.5.3"
 panic-halt = "0.2.0"
+panic-itm = "0.4.2"
 lazy_static = { version = "1.4", features = ["spin_no_std"] }
 log = "0.4.11"
 cortex-m-log = { version = "0.7", features = ["log-integration"] }
@@ -65,9 +66,9 @@ stm32g483 = ["stm32g4/stm32g483"]
 stm32g484 = ["stm32g4/stm32g484"]
 stm32g491 = ["stm32g4/stm32g491"]
 stm32g4a1 = ["stm32g4/stm32g4a1"]
-log-itm = []
+log-itm = ["cortex-m-log/itm"]
 log-rtt = []
-log-semihost = ["cortex-m-log/semihosting" ]
+log-semihost = ["cortex-m-log/semihosting"]
 
 [profile.dev]
 codegen-units = 1

--- a/examples/utils/logger.rs
+++ b/examples/utils/logger.rs
@@ -1,3 +1,4 @@
+#![allow(unsafe_code)]
 cfg_if::cfg_if! {
     if #[cfg(any(feature = "log-itm"))] {
         use panic_itm as _;
@@ -19,7 +20,9 @@ cfg_if::cfg_if! {
                 level: LevelFilter::Info,
                 inner: unsafe {
                     InterruptSync::new(
-                        ItmDest::new(cortex_m::Peripherals::steal().ITM)
+                        // We must not use Peripherals::steal() here to get an ITM instance, as the
+                        // code might expect to be able to call Peripherals::take() later on.
+                        ItmDest::new(core::mem::transmute(()))
                     )
                 },
             };

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -3,10 +3,16 @@
 source [find interface/stlink.cfg]
 source [find target/stm32g4x.cfg]
 
+reset_config srst_only srst_nogate
+init
+
 reset halt
 stm32g4x unlock 0
 reset halt
-
-reset_config srst_only srst_nogate
-init
 flash probe 0
+
+# Uncomment the following lines for ITM logging to "itm.fifo" and adapt core
+# clock (16MHz by default) and pin frequency if necessary:
+#stm32g4x.tpiu configure -protocol uart -traceclk 16000000 -pin-freq 8000000 -output itm.fifo -formatter off
+#stm32g4x.tpiu enable
+#itm ports on


### PR DESCRIPTION
Currently, the logging codes does not compile. Furthermore, the examples panic when ITM logging is activated, because the logger implementation steals the peripherals before the examples have a chance to take() them. This pull request fixes both.

Note that the current development version of OpenOCD supports ITM in stm32f4x.cfg, but not in stm32g4x.cfg - the fix is a single line of code, I'll try to send a patch upstream once I find the time.