### PR TITLE
Update to stm32g4 v0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.0.0"
 [dependencies]
 cortex-m = "0.7.1"
 nb = "0.1.1"
-stm32g4 = "0.13.0"
+stm32g4 = "0.14.0"
 paste = "1.0"
 bitflags = "1.2"
 vcell = "0.1"

--- a/src/fdcan.rs
+++ b/src/fdcan.rs
@@ -522,7 +522,7 @@ where
     {
         I::enable(&rcc.rb);
 
-        if rcc.rb.ccipr.read().fdcansel() == 0 {
+        if rcc.rb.ccipr.read().fdcansel().is_hse() {
             // Select P clock as FDCAN clock source
             rcc.rb.ccipr.modify(|_, w| {
                 // This is sound, as `FdCanClockSource` only contains valid values for this field.
@@ -537,7 +537,7 @@ where
 
         let can = Self::create_can(FdCanConfig::default(), can_instance);
         let reg = can.registers();
-        assert!(reg.endn.read() == 0x87654321_u32);
+        assert!(reg.endn.read().bits() == 0x87654321_u32);
         can
     }
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -129,7 +129,7 @@ macro_rules! flush_txdr {
     ($i2c:expr) => {
         // If a pending TXIS flag is set, write dummy data to TXDR
         if $i2c.isr.read().txis().bit_is_set() {
-            $i2c.txdr.write(|w| unsafe { w.txdata().bits(0) });
+            $i2c.txdr.write(|w| w.txdata().bits(0));
         }
 
         // If TXDR is not flagged as empty, write 1 to flush it
@@ -219,7 +219,7 @@ macro_rules! i2c {
                 i2c.timingr.write(|w| unsafe { w.bits(timing_bits) });
 
                 // Enable the I2C processing
-                i2c.cr1.modify(|_, w| unsafe {
+                i2c.cr1.modify(|_, w| {
                     w.pe()
                         .set_bit()
                         .dnf()
@@ -264,7 +264,7 @@ macro_rules! i2c {
                 // Set START and prepare to send `bytes`.
                 // The START bit can be set even if the bus is BUSY or
                 // I2C is in slave mode.
-                self.i2c.cr2.write(|w| unsafe {
+                self.i2c.cr2.write(|w| {
                     w
                         // Start transfer
                         .start().set_bit()
@@ -286,14 +286,14 @@ macro_rules! i2c {
                     busy_wait!(self.i2c, txis, bit_is_set);
 
                     // Put byte on the wire
-                    self.i2c.txdr.write(|w| unsafe { w.txdata().bits(*byte) });
+                    self.i2c.txdr.write(|w| { w.txdata().bits(*byte) });
                 }
 
                 // Wait until the write finishes before beginning to read.
                 busy_wait!(self.i2c, tc, bit_is_set);
 
                 // reSTART and prepare to receive bytes into `buffer`
-                self.i2c.cr2.write(|w| unsafe {
+                self.i2c.cr2.write(|w| {
                     w
                         // Start transfer
                         .start().set_bit()
@@ -328,7 +328,7 @@ macro_rules! i2c {
             fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
                 assert!(bytes.len() < 256 && bytes.len() > 0);
 
-                self.i2c.cr2.modify(|_, w| unsafe {
+                self.i2c.cr2.modify(|_, w| {
                     w
                         // Start transfer
                         .start().set_bit()
@@ -348,7 +348,7 @@ macro_rules! i2c {
                     busy_wait!(self.i2c, txis, bit_is_set);
 
                     // Put byte on the wire
-                    self.i2c.txdr.write(|w| unsafe { w.txdata().bits(*byte) });
+                    self.i2c.txdr.write(|w| w.txdata().bits(*byte) );
                 }
 
                 // automatic STOP
@@ -371,7 +371,7 @@ macro_rules! i2c {
                 // Set START and prepare to receive bytes into `buffer`.
                 // The START bit can be set even if the bus
                 // is BUSY or I2C is in slave mode.
-                self.i2c.cr2.modify(|_, w| unsafe {
+                self.i2c.cr2.modify(|_, w| {
                     w
                         // Start transfer
                         .start().set_bit()

--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -129,7 +129,7 @@ bus! {
     UART4 => (APB1_1, 19),
     I2C1 => (APB1_1, 21),
     I2C2 => (APB1_1, 22),
-    USB_FS_DEVICE => (APB1_1, 23),
+    USB => (APB1_1, 23),
     FDCAN1 => (APB1_1, 25),
     PWR => (APB1_1, 28),
     I2C3 => (APB1_1, 30),

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -176,9 +176,7 @@ impl Rcc {
         let r = (pll_freq / (pll_cfg.r as u32)).hz();
         let q = match pll_cfg.q {
             Some(div) if div > 1 && div <= 8 => {
-                self.rb
-                    .pllcfgr
-                    .write(move |w| unsafe { w.pllq().bits(div - 1) });
+                self.rb.pllcfgr.write(move |w| w.pllq().bits(div - 1));
                 let req = freq / div as u32;
                 Some(req.hz())
             }


### PR DESCRIPTION
Update to stm32g4 v0.14.0. Removed a few no-longer-necessary `unsafe` blocks, and modified the way enum comparisons are done. 

Note that there are still a few `warning:`s left over e.g. `warning: associated function is never used: \`smenr\``. Let me know if I happened to miss something, but AFAICT those appear to be in v0.13.0 as well...? 