### PR TITLE
PWM example

### DIFF
--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -1,0 +1,30 @@
+//This example puts the timer in PWM mode using the specified pin with a frequency of 100Hz and a duty cycle of 50%.
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+use hal::gpio::gpioa::PA8;
+use hal::gpio::Alternate;
+use hal::gpio::AF6;
+use hal::prelude::*;
+use hal::stm32;
+use stm32g4xx_hal as hal;
+mod utils;
+extern crate cortex_m_rt as rt;
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().expect("cannot take peripherals");
+    let mut rcc = dp.RCC.constrain();
+    let gpioa = dp.GPIOA.split(&mut rcc);
+    let pin: PA8<Alternate<AF6>> = gpioa.pa8.into_alternate();
+
+    let mut pwm = dp.TIM1.pwm(pin, 100.hz(), &mut rcc);
+
+    pwm.set_duty(pwm.get_max_duty() / 2);
+    pwm.enable();
+
+    loop {
+        cortex_m::asm::nop()
+    }
+}


### PR DESCRIPTION
This example is testing the PWM functionality created in pull request #29.

The example I wrote puts the timer in PWM mode using the specified pin with a frequency of 100Hz and a duty cycle of 50%. I can confirm it works, also with different frequencies and duty cycles:
![image](https://user-images.githubusercontent.com/39885512/146389529-0a54ec8d-3845-440b-8ed4-dbeb60311614.png)
