### PR TITLE
Fixes/fdcan

### DIFF
--- a/src/fdcan.rs
+++ b/src/fdcan.rs
@@ -435,6 +435,12 @@ where
         }
     }
 
+    /// Check if the interrupt is triggered
+    #[inline]
+    pub fn has_interrupt(&mut self, interrupt: Interrupt) -> bool {
+        self.control.has_interrupt(interrupt)
+    }
+
     /// Clear specified interrupt
     #[inline]
     pub fn clear_interrupt(&mut self, interrupt: Interrupt) {
@@ -1174,6 +1180,13 @@ where
     #[inline]
     pub fn timestamp(&self) -> u16 {
         self.registers().tscv.read().tsc().bits()
+    }
+
+    /// Check if the interrupt is triggered
+    #[inline]
+    pub fn has_interrupt(&mut self, interrupt: Interrupt) -> bool {
+        let can = self.registers();
+        can.ir.read().bits() & (interrupt as u32) > 0
     }
 
     /// Clear specified interrupt

--- a/src/fdcan/id.rs
+++ b/src/fdcan/id.rs
@@ -212,10 +212,14 @@ impl IdReg {
     /// Returns the identifier.
     pub fn to_id(self) -> Id {
         if self.is_extended() {
-            Id::Extended(unsafe { ExtendedId::new_unchecked(self.0 >> Self::EXTENDED_SHIFT) })
+            Id::Extended(unsafe {
+                ExtendedId::new_unchecked((self.0 >> Self::EXTENDED_SHIFT) & Self::EXTENDED_MASK)
+            })
         } else {
             Id::Standard(unsafe {
-                StandardId::new_unchecked((self.0 >> Self::STANDARD_SHIFT) as u16)
+                StandardId::new_unchecked(
+                    ((self.0 >> Self::STANDARD_SHIFT) & Self::STANDARD_MASK) as u16,
+                )
             })
         }
     }

--- a/src/fdcan/id.rs
+++ b/src/fdcan/id.rs
@@ -41,7 +41,7 @@ impl StandardId {
 
     /// Returns this CAN Identifier as a raw 16-bit integer.
     #[inline]
-    pub(crate) fn as_raw(&self) -> u16 {
+    pub fn as_raw(&self) -> u16 {
         self.0
     }
 }
@@ -88,7 +88,7 @@ impl ExtendedId {
 
     /// Returns this CAN Identifier as a raw 32-bit integer.
     #[inline]
-    pub(crate) fn as_raw(&self) -> u32 {
+    pub fn as_raw(&self) -> u32 {
         self.0
     }
 


### PR DESCRIPTION
Some minor fixes to FdCan.

* Added an has_interrupt function to check if an interrupt is triggered.
* Fix a problem with IdReg.to_id where no mask is used.
* Allow id.as_raw() to be used outside of the crate. While not encouraged, this can be used to for example when an Id has to be modified. Actually using it to create a new id is unsafe.