### PR TITLE
USB device support and usb_serial example

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,7 +1,10 @@
 [target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb -q -x openocd.gdb'
+runner = 'probe-run --connect-under-reset'
 rustflags = [
-  "-C", "link-arg=-Tlink.x"
+  # "-C", "linker=flip-link",
+  "-C", "link-arg=-Tlink.x",
+  "-C", "link-arg=-Tdefmt.x",
+  # "-C", "link-arg=--nmagic",
 ]
 
 [build]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,16 @@
   "rust.all_features": false,
   "rust.features": [
     "rt",
-    "stm32g431"
+    "stm32g473"
+  ],
+  "rust-analyzer.checkOnSave.allTargets": false,
+  "rust-analyzer.checkOnSave.extraArgs": [
+    "--examples",
+  ],
+  "rust-analyzer.cargo.features": [
+    "stm32g473",
+    "usb_fs",
+    "defmt-logging",
+
   ]
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/stm32-rs/stm32g4xx-hal"
 version = "0.0.0"
 
 [dependencies]
-cortex-m = "0.7.1"
+cortex-m = "0.7.3"
 nb = "0.1.1"
 stm32g4 = "0.14.0"
 paste = "1.0"
@@ -44,13 +44,19 @@ default-features = false
 version = "1.1"
 
 [dependencies.defmt]
-version = "0.3.0"
+version = "0.3.1"
+optional = true
+
+[dependencies.stm32-usbd]
+version = "0.6"
 optional = true
 
 [dev-dependencies]
-cortex-m-rt = "0.6.10"
-cortex-m-rtfm = "0.5.1"
+cortex-m-rt = "0.7.1"
+defmt-rtt = "0.3.1"
+cortex-m-rtic = "0.5.8"
 cortex-m-semihosting = "0.3.5"
+panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 panic-semihosting = "0.5.3"
 panic-halt = "0.2.0"
 panic-itm = "0.4.2"
@@ -63,6 +69,8 @@ panic-rtt-target = { version = "0.1.1", features = ["cortex-m"] }
 mpu6050 = "0.1.4"
 bme680 = "0.6.0"
 embedded-sdmmc = "0.3.0"
+usbd-serial = "0.1.1"
+usb-device = "0.2.8"
 
 #TODO: Separate feature sets
 [features]
@@ -80,7 +88,8 @@ stm32g4a1 = ["stm32g4/stm32g4a1"]
 log-itm = ["cortex-m-log/itm"]
 log-rtt = []
 log-semihost = ["cortex-m-log/semihosting"]
-unstable-defmt = ["defmt"]
+defmt-logging = ["defmt"]
+usb_fs = ["stm32-usbd"]
 
 [profile.dev]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ specify your microcontroller on the command line. For example:
 cargo build --example blinky
 ```
 
+## Running examples
+
+Examples can be built and run using `cargo run`. It is necessary to provide any
+required features followed by the name of the chip. To 
+
+```
+cargo run --example usb_serial --features stm32g473 --features usb_fs --release -- --chip STM32G473RETx
+```
+
+A list of chips supported by probe-rs can be found by running
+
+```
+probe-run --list-chips
+```
+
+For furher information, see the documentation for [probe-run](https://github.com/knurling-rs/probe-run).
+
 ### Using as a Dependency
 
 When using this crate as a dependency in your project, the microcontroller can 

--- a/examples/panic.rs
+++ b/examples/panic.rs
@@ -1,0 +1,29 @@
+#![no_main]
+#![no_std]
+
+use defmt_rtt as _;
+
+use panic_probe as _;
+
+use stm32g4 as _;
+
+use defmt::Format;
+
+#[defmt::panic_handler]
+fn panic() -> ! {
+    cortex_m::asm::udf()
+}
+
+pub fn exit() -> ! {
+    loop {
+        cortex_m::asm::bkpt();
+    }
+}
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    defmt::info!("main");
+
+    panic!("Something bad");
+    // defmt::panic!()
+}

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -1,0 +1,132 @@
+//! CDC-ACM serial port example using polling in a busy loop.
+//! This example currently requires an 8MHz external oscillator
+//! and assumed an LED is connected to port A6.
+//!
+//! Further work could be done to setup the HSI48 and the clock
+//! recovery system to generate the USB clock.
+
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+
+use hal::rcc::PllMDiv;
+use hal::rcc::PllNMul;
+use hal::rcc::PllQDiv;
+use hal::rcc::PllRDiv;
+use panic_probe as _;
+
+use stm32g4 as _;
+
+#[cfg(feature = "defmt-logging")]
+#[defmt::panic_handler]
+fn panic() -> ! {
+    cortex_m::asm::udf()
+}
+
+pub fn exit() -> ! {
+    loop {
+        cortex_m::asm::bkpt();
+    }
+}
+
+use hal::rcc::{Config, PLLSrc, Prescaler};
+
+use stm32g4xx_hal as hal;
+
+use hal::prelude::*;
+use hal::stm32;
+use hal::usb::{Peripheral, UsbBus};
+
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    // utils::logger::init();
+
+    let dp = stm32::Peripherals::take().unwrap();
+
+    let rcc = dp.RCC.constrain();
+
+    // This sets the clocks up as follows
+    // - 8 MHz external oscillator
+    // - Sysclck and HCLK at 144 MHz
+    // - APB1 = PCLK1 =  72 MHz
+    // - APB2 = PCLK2 =  72 MHz
+    // - USB = 48 MHz
+    let mut rcc = rcc.freeze(
+        Config::new(hal::rcc::SysClockSrc::HSE(8.mhz()))
+            .pll_cfg(hal::rcc::PllConfig {
+                mux: PLLSrc::HSE(8.mhz()),
+                m: PllMDiv::DIV_1,
+                n: PllNMul::MUL_36,
+                r: Some(PllRDiv::DIV_2),
+                q: Some(PllQDiv::DIV_6),
+                p: None,
+            })
+            .ahb_psc(Prescaler::Div2)
+            .apb_psc(Prescaler::Div2),
+    );
+
+    {
+        use crate::stm32::RCC;
+        let rcc = unsafe { &*RCC::ptr() };
+        // Set clock source for USB to PLL
+        rcc.ccipr.modify(|_, w| w.clk48sel().pllq());
+    }
+
+    // Configure an LED
+    let gpioa = dp.GPIOA.split(&mut rcc);
+
+    let mut led = gpioa.pa6.into_push_pull_output();
+
+    let usb = Peripheral { usb: dp.USB };
+    let usb_bus = UsbBus::new(usb);
+
+    let rx_buffer: [u8; 128] = [0; 128];
+    let tx_buffer: [u8; 128] = [0; 128];
+
+    let mut serial = SerialPort::new_with_store(&usb_bus, rx_buffer, tx_buffer);
+
+    let mut usb_dev = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0x16c0, 0x27dd))
+        .manufacturer("Fake company")
+        .product("Serial port")
+        .serial_number("TEST")
+        .device_class(USB_CLASS_CDC)
+        .build();
+
+    loop {
+        if !usb_dev.poll(&mut [&mut serial]) {
+            continue;
+        }
+
+        let mut buf = [0u8; 64];
+
+        match serial.read(&mut buf) {
+            Ok(count) if count > 0 => {
+                led.set_low().ok(); // Turn on
+
+                // Echo back in upper case
+                for c in buf[0..count].iter_mut() {
+                    if 0x61 <= *c && *c <= 0x7a {
+                        *c &= !0x20;
+                    }
+                }
+
+                let mut write_offset = 0;
+                while write_offset < count {
+                    match serial.write(&buf[write_offset..count]) {
+                        Ok(len) if len > 0 => {
+                            write_offset += len;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        led.set_high().ok(); // Turn off
+    }
+}

--- a/src/fdcan/interrupt.rs
+++ b/src/fdcan/interrupt.rs
@@ -195,8 +195,8 @@ mod tests {
         );
         assert_eq!(Interrupts::from(Interrupt::TxEmpty), Interrupts::TX_EMPTY);
 
-        let mut ints = Interrupts::RX_FIFO0_FULL;
+        let mut ints = Interrupts::RX_FIFO_0_FULL;
         ints |= Interrupt::RxFifo1Full;
-        assert_eq!(ints, Interrupts::RX_FIFO0_FULL | Interrupts::RX_FIFO1_FULL);
+        assert_eq!(ints, Interrupts::RX_FIFO_0_FULL | Interrupts::RX_FIFO_1_FULL);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,3 +85,11 @@ pub mod syscfg;
 pub mod time;
 pub mod timer;
 // pub mod watchdog;
+
+#[cfg(all(
+    feature = "stm32-usbd",
+    any(
+        feature = "stm32g473",
+    )
+))]
+pub mod usb;

--- a/src/rcc/config.rs
+++ b/src/rcc/config.rs
@@ -46,30 +46,279 @@ pub enum PLLSrc {
     HSE_BYPASS(Hertz),
 }
 
-/// PLL divider
-pub type PLLDiv = u8;
+/// Divider for the PLL clock input (M)
+/// This must be set based on the input clock to keep the PLL input frequency within the limits
+/// specified in the datasheet.
+#[derive(Clone, Copy)]
+pub enum PllMDiv {
+    DIV_1 = 0,
+    DIV_2,
+    DIV_3,
+    DIV_4,
+    DIV_5,
+    DIV_6,
+    DIV_7,
+    DIV_8,
+    DIV_9,
+    DIV_10,
+    DIV_11,
+    DIV_12,
+    DIV_13,
+    DIV_14,
+    DIV_15,
+    DIV_16,
+}
 
-/// PLL multiplier
-pub type PLLMul = u8;
+impl PllMDiv {
+    pub fn divisor(&self) -> u32 {
+        (self.clone() as u32) + 1
+    }
+
+    pub fn register_setting(&self) -> u8 {
+        self.clone() as u8
+    }
+}
+
+/// Divider for the PLL Q Output
+#[derive(Clone, Copy)]
+pub enum PllQDiv {
+    DIV_2 = 0,
+    DIV_4,
+    DIV_6,
+    DIV_8,
+}
+
+impl PllQDiv {
+    pub fn divisor(&self) -> u32 {
+        ((self.clone() as u32) + 1) * 2
+    }
+
+    pub fn register_setting(&self) -> u8 {
+        self.clone() as u8
+    }
+}
+
+/// Divider for the PLL R Output
+#[derive(Clone, Copy)]
+pub enum PllRDiv {
+    DIV_2 = 0,
+    DIV_4,
+    DIV_6,
+    DIV_8,
+}
+
+impl PllRDiv {
+    pub fn divisor(&self) -> u32 {
+        ((self.clone() as u32) + 1) * 2
+    }
+
+    pub fn register_setting(&self) -> u8 {
+        self.clone() as u8
+    }
+}
+
+/// Divider for the PLL P Output
+///
+/// Note: The P divider has a PLLP register that can be used to set the divider to either 7 or 17.
+/// It is a complete mystery why anyone would want to do that instead of using the PLLPDIV register
+/// so it's not supported.
+#[derive(Clone, Copy)]
+pub enum PllPDiv {
+    DIV_2 = 2,
+    DIV_3,
+    DIV_4,
+    DIV_5,
+    DIV_6,
+    DIV_7,
+    DIV_8,
+    DIV_9,
+    DIV_10,
+    DIV_11,
+    DIV_12,
+    DIV_13,
+    DIV_14,
+    DIV_15,
+    DIV_16,
+    DIV_17,
+    DIV_18,
+    DIV_19,
+    DIV_20,
+    DIV_21,
+    DIV_22,
+    DIV_23,
+    DIV_24,
+    DIV_25,
+    DIV_26,
+    DIV_27,
+    DIV_28,
+    DIV_29,
+    DIV_30,
+    DIV_31,
+}
+
+impl PllPDiv {
+    pub fn divisor(&self) -> u32 {
+        self.clone() as u32
+    }
+
+    pub fn register_setting(&self) -> u8 {
+        self.clone() as u8
+    }
+}
+
+/// Main PLL multiplication factor for VCO
+#[derive(Clone, Copy)]
+pub enum PllNMul {
+    MUL_8 = 8,
+    MUL_9,
+    MUL_10,
+    MUL_11,
+    MUL_12,
+    MUL_13,
+    MUL_14,
+    MUL_15,
+    MUL_16,
+    MUL_17,
+    MUL_18,
+    MUL_19,
+    MUL_20,
+    MUL_21,
+    MUL_22,
+    MUL_23,
+    MUL_24,
+    MUL_25,
+    MUL_26,
+    MUL_27,
+    MUL_28,
+    MUL_29,
+    MUL_30,
+    MUL_31,
+    MUL_32,
+    MUL_33,
+    MUL_34,
+    MUL_35,
+    MUL_36,
+    MUL_37,
+    MUL_38,
+    MUL_39,
+    MUL_40,
+    MUL_41,
+    MUL_42,
+    MUL_43,
+    MUL_44,
+    MUL_45,
+    MUL_46,
+    MUL_47,
+    MUL_48,
+    MUL_49,
+    MUL_50,
+    MUL_51,
+    MUL_52,
+    MUL_53,
+    MUL_54,
+    MUL_55,
+    MUL_56,
+    MUL_57,
+    MUL_58,
+    MUL_59,
+    MUL_60,
+    MUL_61,
+    MUL_62,
+    MUL_63,
+    MUL_64,
+    MUL_65,
+    MUL_66,
+    MUL_67,
+    MUL_68,
+    MUL_69,
+    MUL_70,
+    MUL_71,
+    MUL_72,
+    MUL_73,
+    MUL_74,
+    MUL_75,
+    MUL_76,
+    MUL_77,
+    MUL_78,
+    MUL_79,
+    MUL_80,
+    MUL_81,
+    MUL_82,
+    MUL_83,
+    MUL_84,
+    MUL_85,
+    MUL_86,
+    MUL_87,
+    MUL_88,
+    MUL_89,
+    MUL_90,
+    MUL_91,
+    MUL_92,
+    MUL_93,
+    MUL_94,
+    MUL_95,
+    MUL_96,
+    MUL_97,
+    MUL_98,
+    MUL_99,
+    MUL_100,
+    MUL_101,
+    MUL_102,
+    MUL_103,
+    MUL_104,
+    MUL_105,
+    MUL_106,
+    MUL_107,
+    MUL_108,
+    MUL_109,
+    MUL_110,
+    MUL_111,
+    MUL_112,
+    MUL_113,
+    MUL_114,
+    MUL_115,
+    MUL_116,
+    MUL_117,
+    MUL_118,
+    MUL_119,
+    MUL_120,
+    MUL_121,
+    MUL_122,
+    MUL_123,
+    MUL_124,
+    MUL_125,
+    MUL_126,
+    MUL_127,
+}
+
+impl PllNMul {
+    pub fn multiplier(&self) -> u32 {
+        self.clone() as u32
+    }
+
+    pub fn register_setting(&self) -> u8 {
+        self.clone() as u8
+    }
+}
 
 /// PLL config
 #[derive(Clone, Copy)]
 pub struct PllConfig {
     pub mux: PLLSrc,
-    pub m: PLLDiv,
-    pub n: PLLMul,
-    pub r: PLLDiv,
-    pub q: Option<PLLDiv>,
-    pub p: Option<PLLDiv>,
+    pub m: PllMDiv,
+    pub n: PllNMul,
+    pub r: Option<PllRDiv>,
+    pub q: Option<PllQDiv>,
+    pub p: Option<PllPDiv>,
 }
 
 impl Default for PllConfig {
     fn default() -> PllConfig {
         PllConfig {
             mux: PLLSrc::HSI,
-            m: 2,
-            n: 8,
-            r: 2,
+            m: PllMDiv::DIV_2,
+            n: PllNMul::MUL_8,
+            r: Some(PllRDiv::DIV_2),
             q: None,
             p: None,
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -8,6 +8,7 @@ pub struct Instant(pub u32);
 pub struct Bps(pub u32);
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Hertz(pub u32);
 
 #[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -1,0 +1,47 @@
+//! # USB peripheral.
+//!
+//! Mostly builds upon the [`stm32_usbd`] crate.
+//!
+//! ## Examples
+//!
+//! See [examples/usb_serial.rs] for a usage example.
+
+use crate::stm32::{RCC, USB};
+
+use stm32_usbd::UsbPeripheral;
+
+pub use stm32_usbd::UsbBus;
+
+pub struct Peripheral {
+    pub usb: USB,
+}
+
+unsafe impl Sync for Peripheral {}
+
+unsafe impl UsbPeripheral for Peripheral {
+    const REGISTERS: *const () = USB::ptr() as *const ();
+    const DP_PULL_UP_FEATURE: bool = true;
+    const EP_MEMORY: *const () = 0x4000_6000 as _;
+    const EP_MEMORY_SIZE: usize = 1024;
+    const EP_MEMORY_ACCESS_2X16: bool = true;
+
+    fn enable() {
+        let rcc = unsafe { &*RCC::ptr() };
+
+        cortex_m::interrupt::free(|_| {
+            // Enable USB peripheral
+            rcc.apb1enr1.modify(|_, w| w.usben().enabled());
+
+            // Reset USB peripheral
+            rcc.apb1rstr1.modify(|_, w| w.usbrst().reset());
+            rcc.apb1rstr1.modify(|_, w| w.usbrst().clear_bit());
+        });
+    }
+
+    fn startup_delay() {
+        // There is a chip specific startup delay. It is not specified for the STM32G4 but the STM32F103 is 1 us to delay for 170 cycles minimum
+        cortex_m::asm::delay(170);
+    }
+}
+
+pub type UsbBusType = UsbBus<Peripheral>;


### PR DESCRIPTION
Draft PR to go in after the separate https://github.com/stm32-rs/stm32g4xx-hal/pull/49 to ease review.

This PR adds the following features:
- Updates dependencies
- Updates vscode settings for rust analyzer
- Adds better defmt support along with using probe-run instead of openocd
- Adds USB device support along with a working usb_serial example

This has been tested on a custom STM32F473 board. If desired I can split this out into separate PRs for the defmt/probe-run and the USB support.