### PR TITLE
ADC claim optional reset

### DIFF
--- a/examples/adc-continious-dma.rs
+++ b/examples/adc-continious-dma.rs
@@ -46,7 +46,9 @@ fn main() -> ! {
 
     info!("Setup Adc1");
     let mut delay = cp.SYST.delay(&rcc.clocks);
-    let mut adc = dp.ADC1.claim(ClockSource::SystemClock, &rcc, &mut delay);
+    let mut adc = dp
+        .ADC1
+        .claim(ClockSource::SystemClock, &rcc, &mut delay, true);
 
     adc.enable_temperature(&dp.ADC12_COMMON);
     adc.set_continuous(Continuous::Continuous);

--- a/examples/adc-continious.rs
+++ b/examples/adc-continious.rs
@@ -40,7 +40,9 @@ fn main() -> ! {
 
     info!("Setup Adc1");
     let mut delay = cp.SYST.delay(&rcc.clocks);
-    let mut adc = dp.ADC1.claim(ClockSource::SystemClock, &rcc, &mut delay);
+    let mut adc = dp
+        .ADC1
+        .claim(ClockSource::SystemClock, &rcc, &mut delay, true);
 
     adc.enable_temperature(&dp.ADC12_COMMON);
     adc.enable_vref(&dp.ADC12_COMMON);

--- a/examples/adc-one-shot-dma.rs
+++ b/examples/adc-one-shot-dma.rs
@@ -47,7 +47,9 @@ fn main() -> ! {
 
     info!("Setup Adc1");
     let mut delay = cp.SYST.delay(&rcc.clocks);
-    let mut adc = dp.ADC1.claim(ClockSource::SystemClock, &rcc, &mut delay);
+    let mut adc = dp
+        .ADC1
+        .claim(ClockSource::SystemClock, &rcc, &mut delay, true);
 
     adc.enable_temperature(&dp.ADC12_COMMON);
     adc.set_continuous(Continuous::Single);

--- a/examples/adc-one-shot.rs
+++ b/examples/adc-one-shot.rs
@@ -33,7 +33,9 @@ fn main() -> ! {
 
     info!("Setup Adc1");
     let mut delay = cp.SYST.delay(&rcc.clocks);
-    let mut adc = dp.ADC1.claim(ClockSource::SystemClock, &rcc, &mut delay);
+    let mut adc = dp
+        .ADC1
+        .claim(ClockSource::SystemClock, &rcc, &mut delay, true);
 
     info!("Setup Gpio");
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1470,6 +1470,7 @@ tim_hal! {
     TIM15: (tim15, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
     TIM16: (tim16, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
     TIM17: (tim17, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
+    TIM20: (tim20, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
 }
 
 pub trait PwmPinEnable {

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1470,6 +1470,16 @@ tim_hal! {
     TIM15: (tim15, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
     TIM16: (tim16, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
     TIM17: (tim17, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
+}
+
+#[cfg(any(
+    feature = "stm32g474",
+    feature = "stm32g483",
+    feature = "stm32g484",
+    feature = "stm32g491",
+    feature = "stm32g4a1"
+))]
+tim_hal! {
     TIM20: (tim20, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
 }
 


### PR DESCRIPTION
Added an extra argument to the ADCs claim function for an optional reset. This is provided because on some devices multiple ADCs share the same common reset.