### PR TITLE
Use fugit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ paste = "1.0"
 bitflags = "1.2"
 vcell = "0.1"
 static_assertions = "1.1"
+fugit = "0.3.5"
 
 [dependencies.cortex-m]
 version = "0.7.7"

--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -7,8 +7,8 @@ use hal::delay::DelayFromCountDownTimer;
 use hal::prelude::*;
 use hal::rcc::Config;
 use hal::stm32;
-use hal::timer::Timer;
 use hal::time::ExtU32;
+use hal::timer::Timer;
 use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;

--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -8,6 +8,7 @@ use hal::prelude::*;
 use hal::rcc::Config;
 use hal::stm32;
 use hal::timer::Timer;
+use hal::time::ExtU32;
 use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;
@@ -34,13 +35,13 @@ fn main() -> ! {
 
     info!("Init Timer2 delay");
     let timer2 = Timer::new(dp.TIM2, &rcc.clocks);
-    let mut delay_tim2 = DelayFromCountDownTimer::new(timer2.start_count_down(100.ms()));
+    let mut delay_tim2 = DelayFromCountDownTimer::new(timer2.start_count_down(100.millis()));
 
     loop {
         info!("Toggle");
         led.toggle().unwrap();
         info!("SYST delay");
-        delay_syst.delay(1000.ms());
+        delay_syst.delay(1000.millis());
         info!("Toggle");
         led.toggle().unwrap();
         info!("TIM2 delay");

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -7,7 +7,7 @@ use crate::hal::{
     nb::block,
     rcc::{Config, RccExt, SysClockSrc},
     stm32::Peripherals,
-    time::U32Ext,
+    time::RateExtU32,
 };
 use fdcan::{
     config::NominalBitTiming,
@@ -47,7 +47,7 @@ fn main() -> ! {
     let dp = Peripherals::take().unwrap();
     let _cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
     let rcc = dp.RCC.constrain();
-    let mut rcc = rcc.freeze(Config::new(SysClockSrc::HSE(24.mhz())));
+    let mut rcc = rcc.freeze(Config::new(SysClockSrc::HSE(24.MHz())));
 
     info!("Split GPIO");
 

--- a/examples/i2c-bme680.rs
+++ b/examples/i2c-bme680.rs
@@ -12,6 +12,7 @@ use hal::prelude::*;
 use hal::stm32;
 use hal::timer::Timer;
 use stm32g4xx_hal as hal;
+use hal::time::{ExtU32, RateExtU32};
 
 use cortex_m_rt::entry;
 use log::info;
@@ -32,11 +33,11 @@ fn main() -> ! {
     let sda = gpiob.pb9.into_alternate_open_drain();
     let scl = gpiob.pb8.into_alternate_open_drain();
 
-    let i2c = dp.I2C1.i2c(sda, scl, Config::new(100.khz()), &mut rcc);
+    let i2c = dp.I2C1.i2c(sda, scl, Config::new(100.kHz()), &mut rcc);
 
     let mut delayer = cp.SYST.delay(&rcc.clocks);
     let timer2 = Timer::new(dp.TIM2, &rcc.clocks);
-    let mut delay = DelayFromCountDownTimer::new(timer2.start_count_down(100.ms()));
+    let mut delay = DelayFromCountDownTimer::new(timer2.start_count_down(100.millis()));
 
     let mut dev =
         Bme680::init(i2c, &mut delayer, I2CAddress::Secondary).expect("Init function failed");

--- a/examples/i2c-bme680.rs
+++ b/examples/i2c-bme680.rs
@@ -10,9 +10,9 @@ use hal::delay::DelayFromCountDownTimer;
 use hal::i2c::Config;
 use hal::prelude::*;
 use hal::stm32;
+use hal::time::{ExtU32, RateExtU32};
 use hal::timer::Timer;
 use stm32g4xx_hal as hal;
-use hal::time::{ExtU32, RateExtU32};
 
 use cortex_m_rt::entry;
 use log::info;

--- a/examples/i2c-mpu6050.rs
+++ b/examples/i2c-mpu6050.rs
@@ -6,8 +6,8 @@
 use hal::i2c::Config;
 use hal::prelude::*;
 use hal::stm32;
-use stm32g4xx_hal as hal;
 use hal::time::{ExtU32, RateExtU32};
+use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;
 use log::info;

--- a/examples/i2c-mpu6050.rs
+++ b/examples/i2c-mpu6050.rs
@@ -7,6 +7,7 @@ use hal::i2c::Config;
 use hal::prelude::*;
 use hal::stm32;
 use stm32g4xx_hal as hal;
+use hal::time::{ExtU32, RateExtU32};
 
 use cortex_m_rt::entry;
 use log::info;
@@ -28,7 +29,7 @@ fn main() -> ! {
     let sda = gpiob.pb9.into_alternate_open_drain();
     let scl = gpiob.pb8.into_alternate_open_drain();
 
-    let i2c = dp.I2C1.i2c(sda, scl, Config::new(100.khz()), &mut rcc);
+    let i2c = dp.I2C1.i2c(sda, scl, Config::new(100.kHz()), &mut rcc);
 
     let mut mpu = Mpu6050::new(i2c);
     let mut delay = cp.SYST.delay(&rcc.clocks);
@@ -39,6 +40,6 @@ fn main() -> ! {
         let gyro = mpu.get_gyro().expect("cannot read gyro");
         let temp = mpu.get_temp().expect("cannot read temperature");
         info!("acc: {:?}, gyro: {:?}, temp: {:?}C", acc, gyro, temp);
-        delay.delay(250.ms());
+        delay.delay(250.millis());
     }
 }

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -7,6 +7,7 @@ use hal::i2c::Config;
 use hal::prelude::*;
 use hal::stm32;
 use stm32g4xx_hal as hal;
+use hal::time::RateExtU32;
 
 use cortex_m_rt::entry;
 use log::info;
@@ -25,7 +26,7 @@ fn main() -> ! {
     let sda = gpiob.pb9.into_alternate_open_drain();
     let scl = gpiob.pb8.into_alternate_open_drain();
 
-    let mut i2c = dp.I2C1.i2c(sda, scl, Config::new(40.khz()), &mut rcc);
+    let mut i2c = dp.I2C1.i2c(sda, scl, Config::new(40.kHz()), &mut rcc);
     // Alternatively, it is possible to specify the exact timing as follows (see the documentation
     // of with_timing() for an explanation of the constant):
     //let mut i2c = dp

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -6,8 +6,8 @@
 use hal::i2c::Config;
 use hal::prelude::*;
 use hal::stm32;
-use stm32g4xx_hal as hal;
 use hal::time::RateExtU32;
+use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;
 use log::info;

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -9,6 +9,7 @@ use hal::gpio::AF6;
 use hal::prelude::*;
 use hal::stm32;
 use stm32g4xx_hal as hal;
+use hal::time::RateExtU32;
 mod utils;
 extern crate cortex_m_rt as rt;
 
@@ -19,7 +20,7 @@ fn main() -> ! {
     let gpioa = dp.GPIOA.split(&mut rcc);
     let pin: PA8<Alternate<AF6>> = gpioa.pa8.into_alternate();
 
-    let mut pwm = dp.TIM1.pwm(pin, 100.hz(), &mut rcc);
+    let mut pwm = dp.TIM1.pwm(pin, 100.Hz(), &mut rcc);
 
     pwm.set_duty(pwm.get_max_duty() / 2);
     pwm.enable();

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -8,8 +8,8 @@ use hal::gpio::Alternate;
 use hal::gpio::AF6;
 use hal::prelude::*;
 use hal::stm32;
-use stm32g4xx_hal as hal;
 use hal::time::RateExtU32;
+use stm32g4xx_hal as hal;
 mod utils;
 extern crate cortex_m_rt as rt;
 

--- a/examples/spi-example.rs
+++ b/examples/spi-example.rs
@@ -7,7 +7,7 @@
 
 use crate::hal::{
     block, delay::DelayFromCountDownTimer, gpio::gpioa::PA5, gpio::gpioa::PA6, gpio::gpioa::PA7,
-    gpio::Alternate, gpio::AF5, prelude::*, rcc::Config, spi, stm32::Peripherals, timer::Timer,
+    gpio::Alternate, gpio::AF5, prelude::*, rcc::Config, spi, stm32::Peripherals, timer::Timer, time::{ExtU32, RateExtU32}
 };
 
 use cortex_m_rt::entry;
@@ -25,7 +25,7 @@ fn main() -> ! {
     let rcc = dp.RCC.constrain();
     let mut rcc = rcc.freeze(Config::hsi());
     let timer2 = Timer::new(dp.TIM2, &rcc.clocks);
-    let mut delay_tim2 = DelayFromCountDownTimer::new(timer2.start_count_down(100.ms()));
+    let mut delay_tim2 = DelayFromCountDownTimer::new(timer2.start_count_down(100.millis()));
 
     let gpioa = dp.GPIOA.split(&mut rcc);
     let sclk: PA5<Alternate<AF5>> = gpioa.pa5.into_alternate();
@@ -34,7 +34,7 @@ fn main() -> ! {
 
     let mut spi = dp
         .SPI1
-        .spi((sclk, miso, mosi), spi::MODE_0, 400.khz(), &mut rcc);
+        .spi((sclk, miso, mosi), spi::MODE_0, 400.kHz(), &mut rcc);
     let mut cs = gpioa.pa8.into_push_pull_output();
     cs.set_high().unwrap();
 

--- a/examples/spi-example.rs
+++ b/examples/spi-example.rs
@@ -6,8 +6,19 @@
 #![no_std]
 
 use crate::hal::{
-    block, delay::DelayFromCountDownTimer, gpio::gpioa::PA5, gpio::gpioa::PA6, gpio::gpioa::PA7,
-    gpio::Alternate, gpio::AF5, prelude::*, rcc::Config, spi, stm32::Peripherals, timer::Timer, time::{ExtU32, RateExtU32}
+    block,
+    delay::DelayFromCountDownTimer,
+    gpio::gpioa::PA5,
+    gpio::gpioa::PA6,
+    gpio::gpioa::PA7,
+    gpio::Alternate,
+    gpio::AF5,
+    prelude::*,
+    rcc::Config,
+    spi,
+    stm32::Peripherals,
+    time::{ExtU32, RateExtU32},
+    timer::Timer,
 };
 
 use cortex_m_rt::entry;

--- a/examples/spi-sd.rs
+++ b/examples/spi-sd.rs
@@ -18,6 +18,7 @@ use hal::stm32;
 use hal::stm32::Peripherals;
 use hal::timer::Timer;
 use stm32g4xx_hal as hal;
+use hal::time::RateExtU32;
 
 use embedded_sdmmc::{
     Block, BlockCount, BlockDevice, BlockIdx, Controller, Error, Mode, TimeSource, Timestamp,
@@ -50,7 +51,7 @@ fn main() -> ! {
 
     let mut spi = dp
         .SPI2
-        .spi((sck, miso, mosi), spi::MODE_0, 400.khz(), &mut rcc);
+        .spi((sck, miso, mosi), spi::MODE_0, 400.kHz(), &mut rcc);
 
     struct Clock;
 

--- a/examples/spi-sd.rs
+++ b/examples/spi-sd.rs
@@ -16,9 +16,9 @@ use hal::rcc::Config;
 use hal::spi;
 use hal::stm32;
 use hal::stm32::Peripherals;
+use hal::time::RateExtU32;
 use hal::timer::Timer;
 use stm32g4xx_hal as hal;
-use hal::time::RateExtU32;
 
 use embedded_sdmmc::{
     Block, BlockCount, BlockDevice, BlockIdx, Controller, Error, Mode, TimeSource, Timestamp,

--- a/examples/uart-dma.rs
+++ b/examples/uart-dma.rs
@@ -12,6 +12,7 @@ use hal::prelude::*;
 use hal::serial::*;
 use hal::{rcc, stm32};
 use stm32g4xx_hal as hal;
+use hal::time::ExtU32;
 
 use cortex_m_rt::entry;
 use log::info;
@@ -70,7 +71,7 @@ fn main() -> ! {
     loop {
         while !transfer.get_transfer_complete_flag() {}
 
-        delay_syst.delay(1000.ms());
+        delay_syst.delay(1000.millis());
         led.toggle().unwrap();
         transfer.restart(|_tx| {});
     }

--- a/examples/uart-dma.rs
+++ b/examples/uart-dma.rs
@@ -10,9 +10,9 @@ use core::fmt::Write;
 use hal::dma::{config::DmaConfig, stream::DMAExt, TransferExt};
 use hal::prelude::*;
 use hal::serial::*;
+use hal::time::ExtU32;
 use hal::{rcc, stm32};
 use stm32g4xx_hal as hal;
-use hal::time::ExtU32;
 
 use cortex_m_rt::entry;
 use log::info;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -43,9 +43,7 @@ use cortex_m::peripheral::SYST;
 
 use crate::nb::block;
 use crate::time::ExtU32;
-use embedded_hal::{
-    blocking::delay::{DelayMs, DelayUs},
-};
+use embedded_hal::blocking::delay::{DelayMs, DelayUs};
 
 pub trait CountDown: embedded_hal::timer::CountDown {
     fn max_period(&self) -> MicroSecond;
@@ -120,7 +118,7 @@ macro_rules! impl_delay_from_count_down_timer  {
                     assert!(time_left_us <= max_sleep_us);
 
                     let time_left: MicroSecond = (time_left_us as u32).micros();
-                    
+
                     // Only sleep
                     if time_left.ticks() > 0 {
                         self.0.start(time_left);

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -42,11 +42,14 @@ pub use cortex_m::delay::*;
 use cortex_m::peripheral::SYST;
 
 use crate::nb::block;
-use crate::time::{Hertz, U32Ext};
+use crate::time::ExtU32;
 use embedded_hal::{
     blocking::delay::{DelayMs, DelayUs},
-    timer::CountDown,
 };
+
+pub trait CountDown: embedded_hal::timer::CountDown {
+    fn max_period(&self) -> MicroSecond;
+}
 
 pub trait SYSTDelayExt {
     fn delay(self, clocks: &Clocks) -> Delay;
@@ -54,7 +57,7 @@ pub trait SYSTDelayExt {
 
 impl SYSTDelayExt for SYST {
     fn delay(self, clocks: &Clocks) -> Delay {
-        Delay::new(self, clocks.ahb_clk.0)
+        Delay::new(self, clocks.ahb_clk.raw())
     }
 }
 
@@ -69,7 +72,7 @@ impl DelayExt for Delay {
     where
         T: Into<MicroSecond>,
     {
-        self.delay_us(delay.into().0)
+        self.delay_us(delay.into().ticks())
     }
 }
 
@@ -94,28 +97,33 @@ macro_rules! impl_delay_from_count_down_timer  {
 
             impl<T> $Delay<u32> for DelayFromCountDownTimer<T>
             where
-                T: CountDown<Time = Hertz>,
+                T: CountDown<Time = MicroSecond>,
             {
                 fn $delay(&mut self, t: u32) {
-                    let mut time_left = t;
+                    let mut time_left_us = t as u64 * $num;
 
-                    // Due to the LpTimer having only a 3 bit scaler, it is
-                    // possible that the max timeout we can set is
-                    // (128 * 65536) / clk_hz milliseconds.
-                    // Assuming the fastest clk_hz = 480Mhz this is roughly ~17ms,
-                    // or a frequency of ~57.2Hz. We use a 60Hz frequency for each
-                    // loop step here to ensure that we stay within these bounds.
-                    let looping_delay = $num / 60;
-                    let looping_delay_hz = Hertz($num / looping_delay);
+                    let max_sleep = self.0.max_period();
+                    let max_sleep_us = max_sleep.to_micros() as u64;
 
-                    self.0.start(looping_delay_hz);
-                    while time_left > looping_delay {
-                        block!(self.0.wait()).ok();
-                        time_left -= looping_delay;
+                    if time_left_us > max_sleep_us {
+                        self.0.start(max_sleep);
+
+                        // Process the time one max_sleep duration at a time
+                        // to avoid overflowing both u32 and the timer
+                        for _ in 0..(time_left_us / max_sleep_us) {
+                            block!(self.0.wait()).ok();
+                            time_left_us -= max_sleep_us;
+                        }
                     }
 
-                    if time_left > 0 {
-                        self.0.start(($num / time_left).hz());
+                    assert!(time_left_us <= u32::MAX as u64);
+                    assert!(time_left_us <= max_sleep_us);
+
+                    let time_left: MicroSecond = (time_left_us as u32).micros();
+                    
+                    // Only sleep
+                    if time_left.ticks() > 0 {
+                        self.0.start(time_left);
                         block!(self.0.wait()).ok();
                     }
                 }
@@ -123,7 +131,7 @@ macro_rules! impl_delay_from_count_down_timer  {
 
             impl<T> $Delay<u16> for DelayFromCountDownTimer<T>
             where
-                T: CountDown<Time = Hertz>,
+                T: CountDown<Time = MicroSecond>,
             {
                 fn $delay(&mut self, t: u16) {
                     self.$delay(t as u32);
@@ -132,7 +140,7 @@ macro_rules! impl_delay_from_count_down_timer  {
 
             impl<T> $Delay<u8> for DelayFromCountDownTimer<T>
             where
-                T: CountDown<Time = Hertz>,
+                T: CountDown<Time = MicroSecond>,
             {
                 fn $delay(&mut self, t: u8) {
                     self.$delay(t as u32);
@@ -144,5 +152,5 @@ macro_rules! impl_delay_from_count_down_timer  {
 
 impl_delay_from_count_down_timer! {
     (DelayMs, delay_ms, 1_000),
-    (DelayUs, delay_us, 1_000_000)
+    (DelayUs, delay_us, 1)
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -75,16 +75,16 @@ impl Config {
             return bits;
         }
         let speed = self.speed.unwrap();
-        let (psc, scll, sclh, sdadel, scldel) = if speed.0 <= 100_000 {
+        let (psc, scll, sclh, sdadel, scldel) = if speed.raw() <= 100_000 {
             let psc = 3;
-            let scll = cmp::min((((i2c_clk.0 >> 1) / (psc + 1)) / speed.0) - 1, 255);
+            let scll = cmp::min((((i2c_clk.raw() >> 1) / (psc + 1)) / speed.raw()) - 1, 255);
             let sclh = scll - 4;
             let sdadel = 2;
             let scldel = 4;
             (psc, scll, sclh, sdadel, scldel)
         } else {
             let psc = 1;
-            let scll = cmp::min((((i2c_clk.0 >> 1) / (psc + 1)) / speed.0) - 1, 255);
+            let scll = cmp::min((((i2c_clk.raw() >> 1) / (psc + 1)) / speed.raw()) - 1, 255);
             let sclh = scll - 6;
             let sdadel = 1;
             let scldel = 3;

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -195,7 +195,7 @@ use crate::stm32::TIM5;
 use crate::stm32::{TIM1, TIM15, TIM16, TIM17, TIM2, TIM3, TIM4, TIM8};
 
 use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
-use crate::time::{Hertz, NanoSecond, U32Ext};
+use crate::time::{Hertz, NanoSecond, ExtU32, RateExtU32};
 
 #[cfg(any(
     feature = "stm32g471",
@@ -1029,13 +1029,13 @@ pins! {
 // Returns (arr, psc)
 fn calculate_frequency_32bit(base_freq: Hertz, freq: Hertz, alignment: Alignment) -> (u32, u16) {
     let divisor = if let Alignment::Center = alignment {
-        freq.0 * 2
+        freq * 2
     } else {
-        freq.0
+        freq
     };
 
     // Round to the nearest period
-    let arr = (base_freq.0 + (divisor >> 1)) / divisor - 1;
+    let arr = (base_freq + (divisor / 2)) / divisor - 1;
 
     (arr, 0)
 }
@@ -1071,7 +1071,7 @@ fn calculate_deadtime(base_freq: Hertz, deadtime: NanoSecond) -> (u8, u8) {
     // Cortex-M7 has 32x32->64 multiply but no 64-bit divide
     // Divide by 100000 then 10000 by multiplying and shifting
     // This can't overflow because both values being multiplied are u32
-    let deadtime_ticks = deadtime.0 as u64 * base_freq.0 as u64;
+    let deadtime_ticks = deadtime.ticks() as u64 * base_freq.raw() as u64;
     // Make sure we won't overflow when multiplying; DTG is max 1008 ticks and CKD is max prescaler of 4
     // so deadtimes over 4032 ticks are impossible (4032*10^9 before dividing)
     assert!(deadtime_ticks <= 4_032_000_000_000u64);
@@ -1210,7 +1210,7 @@ macro_rules! tim_hal {
                         $TIMX::reset(rcc_ptr);
                     }
 
-                    let clk = $TIMX::get_timer_frequency(&rcc.clocks).0;
+                    let clk = $TIMX::get_timer_frequency(&rcc.clocks).raw();
 
                     PwmBuilder {
                         _tim: PhantomData,
@@ -1219,12 +1219,12 @@ macro_rules! tim_hal {
                         _fault: PhantomData,
                         _comp: PhantomData,
                         alignment: Alignment::Left,
-                        base_freq: clk.hz(),
+                        base_freq: clk.Hz(),
                         count: CountSettings::Explicit { period: 65535, prescaler: 0, },
                         bkin_enabled: false,
                         bkin2_enabled: false,
                         fault_polarity: Polarity::ActiveLow,
-                        deadtime: 0.ns(),
+                        deadtime: 0.nanos(),
                     }
                 }
             }
@@ -1786,8 +1786,7 @@ macro_rules! lptim_hal {
                     $TIMX::reset(rcc_ptr);
                 }
 
-                let clk = $TIMX::get_timer_frequency(&rcc.clocks).0;
-                let freq = freq.0;
+                let clk = $TIMX::get_timer_frequency(&rcc.clocks);
                 let reload = clk / freq;
                 assert!(reload < 128 * (1 << 16));
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -195,7 +195,7 @@ use crate::stm32::TIM5;
 use crate::stm32::{TIM1, TIM15, TIM16, TIM17, TIM2, TIM3, TIM4, TIM8};
 
 use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
-use crate::time::{Hertz, NanoSecond, ExtU32, RateExtU32};
+use crate::time::{ExtU32, Hertz, NanoSecond, RateExtU32};
 
 #[cfg(any(
     feature = "stm32g471",

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -457,7 +457,7 @@ macro_rules! uart_lp {
                 // try SYSCLK if PCLK is not high enough. We could also select 8x oversampling
                 // instead of 16x.
 
-                let clk = <$USARTX as RccBus>::Bus::get_frequency(&rcc.clocks).0 as u64;
+                let clk = <$USARTX as RccBus>::Bus::get_frequency(&rcc.clocks).raw() as u64;
                 let bdr = config.baudrate.0 as u64;
                 let div = ($clk_mul * clk) / bdr;
                 if div < 16 {
@@ -604,7 +604,7 @@ macro_rules! uart_full {
                 // try SYSCLK if PCLK is not high enough. We could also select 8x oversampling
                 // instead of 16x.
 
-                let clk = <$USARTX as RccBus>::Bus::get_frequency(&rcc.clocks).0 as u64;
+                let clk = <$USARTX as RccBus>::Bus::get_frequency(&rcc.clocks).raw() as u64;
                 let bdr = config.baudrate.0 as u64;
                 let clk_mul = 1;
                 let div = (clk_mul * clk) / bdr;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -114,8 +114,8 @@ macro_rules! spi {
                 // disable SS output
                 spi.cr2.write(|w| w.ssoe().clear_bit());
 
-                let spi_freq = speed.into().0;
-                let bus_freq = <$SPIX as RccBus>::Bus::get_frequency(&rcc.clocks).0;
+                let spi_freq = speed.into().raw();
+                let bus_freq = <$SPIX as RccBus>::Bus::get_frequency(&rcc.clocks).raw();
                 let br = match bus_freq / spi_freq {
                     0 => unreachable!(),
                     1..=2 => 0b000,

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,3 +1,6 @@
+/// This code has been taken from the stm32g0xx-hal project and modified slightly to support
+/// STM32G4xx MCUs.
+
 pub use fugit::{
     Duration, ExtU32, HertzU32 as Hertz, HoursDurationU32 as Hour,
     MicrosDurationU32 as MicroSecond, MinutesDurationU32 as Minute, NanosDurationU32 as NanoSecond,

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,7 @@
 pub use fugit::{
-    ExtU32, HertzU32 as Hertz, Duration, HoursDurationU32 as Hour, MicrosDurationU32 as MicroSecond,
-    MinutesDurationU32 as Minute, RateExtU32, SecsDurationU32 as Second, NanosDurationU32 as NanoSecond
+    Duration, ExtU32, HertzU32 as Hertz, HoursDurationU32 as Hour,
+    MicrosDurationU32 as MicroSecond, MinutesDurationU32 as Minute, NanosDurationU32 as NanoSecond,
+    RateExtU32, SecsDurationU32 as Second,
 };
 
 /// Baudrate

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,43 +1,83 @@
-use core::ops::{Add, Div};
+pub use fugit::{
+    ExtU32, HertzU32 as Hertz, Duration, HoursDurationU32 as Hour, MicrosDurationU32 as MicroSecond,
+    MinutesDurationU32 as Minute, RateExtU32, SecsDurationU32 as Second, NanosDurationU32 as NanoSecond
+};
 
-/// A measurement of a monotonically nondecreasing clock
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
-pub struct Instant(pub u32);
-
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
+/// Baudrate
+#[derive(Debug, Eq, PartialEq, PartialOrd, Clone, Copy)]
 pub struct Bps(pub u32);
 
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
-pub struct Hertz(pub u32);
+/// A measurement of a monotonically nondecreasing clock
+pub type Instant = fugit::TimerInstantU32<1_000_000>;
 
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
-pub struct MicroSecond(pub u32);
+/// WeekDay (1-7)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WeekDay(pub u32);
 
-#[derive(Debug, PartialEq, PartialOrd, Clone, Copy)]
-pub struct NanoSecond(pub u32);
+/// Date (1-31)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MonthDay(pub u32);
 
-/// Extension trait that adds convenience methods to the `u32` type
+/// Week (1-52)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Week(pub u32);
+
+/// Month (1-12)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Month(pub u32);
+
+/// Year
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Year(pub u32);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Time {
+    pub hours: u32,
+    pub minutes: u32,
+    pub seconds: u32,
+    pub daylight_savings: bool,
+}
+
+impl Time {
+    pub fn new(hours: Hour, minutes: Minute, seconds: Second, daylight_savings: bool) -> Self {
+        Self {
+            hours: hours.ticks(),
+            minutes: minutes.ticks(),
+            seconds: seconds.ticks(),
+            daylight_savings,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Date {
+    pub day: u32,
+    pub month: u32,
+    pub year: u32,
+}
+
+impl Date {
+    pub fn new(year: Year, month: Month, day: MonthDay) -> Self {
+        Self {
+            day: day.0,
+            month: month.0,
+            year: year.0,
+        }
+    }
+}
+
 pub trait U32Ext {
     /// Wrap in `Bps`
     fn bps(self) -> Bps;
 
-    /// Wrap in `Hertz`
-    fn hz(self) -> Hertz;
+    /// Day in month
+    fn day(self) -> MonthDay;
 
-    /// Wrap in `Hertz`
-    fn khz(self) -> Hertz;
+    /// Month
+    fn month(self) -> Month;
 
-    /// Wrap in `Hertz`
-    fn mhz(self) -> Hertz;
-
-    /// Wrap in `NanoSecond`
-    fn ns(self) -> NanoSecond;
-
-    /// Wrap in `MicroSecond`
-    fn us(self) -> MicroSecond;
-
-    /// Wrap in `MicroSecond`
-    fn ms(self) -> MicroSecond;
+    /// Year
+    fn year(self) -> Year;
 }
 
 impl U32Ext for u32 {
@@ -45,126 +85,30 @@ impl U32Ext for u32 {
         assert!(self > 0);
         Bps(self)
     }
-
-    fn hz(self) -> Hertz {
-        assert!(self > 0);
-        Hertz(self)
+    fn day(self) -> MonthDay {
+        MonthDay(self)
     }
 
-    fn khz(self) -> Hertz {
-        Hertz(self.saturating_mul(1_000))
+    fn month(self) -> Month {
+        Month(self)
     }
 
-    fn mhz(self) -> Hertz {
-        Hertz(self.saturating_mul(1_000_000))
-    }
-
-    fn ms(self) -> MicroSecond {
-        MicroSecond(self.saturating_mul(1_000))
-    }
-
-    fn us(self) -> MicroSecond {
-        MicroSecond(self)
-    }
-
-    fn ns(self) -> NanoSecond {
-        NanoSecond(self)
+    fn year(self) -> Year {
+        Year(self)
     }
 }
 
-impl Hertz {
-    pub fn duration(self, cycles: u32) -> MicroSecond {
-        let cycles = cycles as u64;
-        let clk = self.0 as u64;
-        let us = cycles.saturating_mul(1_000_000_u64) / clk;
-        MicroSecond(us as u32)
-    }
+pub fn duration(hz: Hertz, cycles: u32) -> MicroSecond {
+    let cycles = cycles as u64;
+    let clk = hz.raw() as u64;
+    let us = cycles.saturating_mul(1_000_000_u64) / clk;
+    MicroSecond::from_ticks(us as u32)
 }
 
-impl Add for Hertz {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self::Output {
-        Self(self.0 + other.0)
-    }
-}
-
-impl Div for Hertz {
-    type Output = u32;
-
-    fn div(self, other: Self) -> Self::Output {
-        self.0 / other.0
-    }
-}
-
-impl Div<u32> for Hertz {
-    type Output = Hertz;
-
-    fn div(self, other: u32) -> Self::Output {
-        Self(self.0 / other)
-    }
-}
-
-impl MicroSecond {
-    pub fn cycles(self, clk: Hertz) -> u32 {
-        assert!(self.0 > 0);
-        let clk = clk.0 as u64;
-        let period = self.0 as u64;
-        let cycles = clk.saturating_mul(period) / 1_000_000_u64;
-        cycles as u32
-    }
-}
-
-impl Add for MicroSecond {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self::Output {
-        Self(self.0 + other.0)
-    }
-}
-
-impl From<Hertz> for MicroSecond {
-    fn from(freq: Hertz) -> MicroSecond {
-        assert!(freq.0 <= 1_000_000);
-        MicroSecond(1_000_000 / freq.0)
-    }
-}
-
-impl From<MicroSecond> for Hertz {
-    fn from(period: MicroSecond) -> Hertz {
-        assert!(period.0 > 0 && period.0 <= 1_000_000);
-        Hertz(1_000_000 / period.0)
-    }
-}
-
-impl NanoSecond {
-    pub fn cycles(self, clk: Hertz) -> u32 {
-        assert!(self.0 > 0);
-        let clk = clk.0 as u64;
-        let period = self.0 as u64;
-        let cycles = clk.saturating_mul(period) / 1_000_000_000u64;
-        cycles as u32
-    }
-}
-
-impl Add for NanoSecond {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self::Output {
-        Self(self.0 + other.0)
-    }
-}
-
-impl From<Hertz> for NanoSecond {
-    fn from(freq: Hertz) -> NanoSecond {
-        assert!(freq.0 <= 1_000_000_000);
-        NanoSecond(1_000_000_000 / freq.0)
-    }
-}
-
-impl From<NanoSecond> for Hertz {
-    fn from(period: NanoSecond) -> Hertz {
-        assert!(period.0 > 0 && period.0 <= 1_000_000_000);
-        Hertz(1_000_000_000 / period.0)
-    }
+pub fn cycles(ms: MicroSecond, clk: Hertz) -> u32 {
+    assert!(ms.ticks() > 0);
+    let clk = clk.raw() as u64;
+    let period = ms.ticks() as u64;
+    let cycles = clk.saturating_mul(period) / 1_000_000_u64;
+    cycles as u32
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -6,13 +6,14 @@
 use cast::{u16, u32};
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::{DCB, DWT, SYST};
-use embedded_hal::timer::{Cancel, CountDown, Periodic};
+use embedded_hal::timer::{Cancel, Periodic, CountDown as _};
+use crate::delay::CountDown;
 use void::Void;
 
 use crate::stm32::RCC;
 
 use crate::rcc::{self, Clocks};
-use crate::time::Hertz;
+use crate::time::{Hertz, MicroSecond};
 
 /// Timer wrapper
 pub struct Timer<TIM> {
@@ -28,12 +29,11 @@ pub struct CountDownTimer<TIM> {
 
 impl<TIM> Timer<TIM>
 where
-    CountDownTimer<TIM>: CountDown<Time = Hertz>,
+    CountDownTimer<TIM>: CountDown<Time = MicroSecond>,
 {
     /// Starts timer in count down mode at a given frequency
     pub fn start_count_down<T>(self, timeout: T) -> CountDownTimer<TIM>
-    where
-        T: Into<Hertz>,
+    where T: Into<MicroSecond>
     {
         let Self { tim, clk } = self;
         let mut timer = CountDownTimer { tim, clk };
@@ -87,14 +87,14 @@ impl CountDownTimer<SYST> {
     }
 }
 
-impl CountDown for CountDownTimer<SYST> {
-    type Time = Hertz;
+impl embedded_hal::timer::CountDown for CountDownTimer<SYST> {
+    type Time = MicroSecond;
 
     fn start<T>(&mut self, timeout: T)
     where
-        T: Into<Hertz>,
+        T: Into<MicroSecond>,
     {
-        let rvr = self.clk.0 / timeout.into().0 - 1;
+        let rvr = crate::time::cycles(timeout.into(), self.clk) - 1;
 
         assert!(rvr < (1 << 24));
 
@@ -109,6 +109,12 @@ impl CountDown for CountDownTimer<SYST> {
         } else {
             Err(nb::Error::WouldBlock)
         }
+    }
+}
+
+impl CountDown for CountDownTimer<SYST> {
+    fn max_period(&self) -> MicroSecond {
+        crate::time::duration(self.clk, (1 << 24) - 1)
     }
 }
 
@@ -158,7 +164,7 @@ impl MonoTimer {
     /// Returns an `Instant` corresponding to "now"
     pub fn now(self) -> Instant {
         Instant {
-            now: DWT::get_cycle_count(),
+            now: DWT::cycle_count(),
         }
     }
 }
@@ -172,7 +178,7 @@ pub struct Instant {
 impl Instant {
     /// Ticks elapsed since the `Instant` was created
     pub fn elapsed(self) -> u32 {
-        DWT::get_cycle_count().wrapping_sub(self.now)
+        DWT::cycle_count().wrapping_sub(self.now)
     }
 }
 
@@ -249,24 +255,24 @@ macro_rules! hal {
                 }
             }
 
-            impl CountDown for CountDownTimer<$TIM> {
-                type Time = Hertz;
+            impl embedded_hal::timer::CountDown for CountDownTimer<$TIM> {
+                type Time = MicroSecond;
 
                 fn start<T>(&mut self, timeout: T)
                 where
-                    T: Into<Hertz>,
+                    T: Into<MicroSecond>,
                 {
                     // pause
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
                     // reset counter
                     self.tim.cnt.reset();
 
-                    let frequency = timeout.into().0;
-                    let ticks = self.clk.0 / frequency;
+                    let ticks = crate::time::cycles(timeout.into(), self.clk);
 
                     let psc = u16((ticks - 1) / (1 << 16)).unwrap();
                     self.tim.psc.write(|w| unsafe {w.psc().bits(psc)} );
 
+                    // TODO: TIM2 and TIM5 are 32 bit
                     let arr = u16(ticks / u32(psc + 1)).unwrap();
                     self.tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
 
@@ -286,6 +292,13 @@ macro_rules! hal {
                         self.tim.sr.modify(|_, w| w.uif().clear_bit());
                         Ok(())
                     }
+                }
+            }
+
+            impl CountDown for CountDownTimer<$TIM> {
+                fn max_period(&self) -> MicroSecond {
+                    // TODO: TIM2 and TIM5 are 32 bit
+                    crate::time::duration(self.clk, u16::MAX as u32)
                 }
             }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -3,11 +3,11 @@
 //! Pins can be used for PWM output in both push-pull mode (`Alternate`) and open-drain mode
 //! (`AlternateOD`).
 
+use crate::delay::CountDown;
 use cast::{u16, u32};
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::{DCB, DWT, SYST};
-use embedded_hal::timer::{Cancel, Periodic, CountDown as _};
-use crate::delay::CountDown;
+use embedded_hal::timer::{Cancel, CountDown as _, Periodic};
 use void::Void;
 
 use crate::stm32::RCC;
@@ -33,7 +33,8 @@ where
 {
     /// Starts timer in count down mode at a given frequency
     pub fn start_count_down<T>(self, timeout: T) -> CountDownTimer<TIM>
-    where T: Into<MicroSecond>
+    where
+        T: Into<MicroSecond>,
     {
         let Self { tim, clk } = self;
         let mut timer = CountDownTimer { tim, clk };


### PR DESCRIPTION
This first started with me trying to implement rtc for this crate by stealing it from stm32g0xx-hal. I noticed there were some differences.

This PR changes the time related types to use fugit to make the crate a bit more consistent with stm32g0xx-hal.

Is this at all something we want?

~(Not at all tested on real hardware yet)~ - Some testing done