### PR TITLE
Opamp pga-mode

### DIFF
--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -1,0 +1,87 @@
+//! Integrated opamps.
+
+#![no_std]
+#![no_main]
+
+use stm32g4xx_hal::adc::AdcClaim;
+use stm32g4xx_hal::adc::ClockSource;
+use stm32g4xx_hal::gpio::gpioa::*;
+use stm32g4xx_hal::gpio::gpiob::*;
+use stm32g4xx_hal::gpio::Analog;
+use stm32g4xx_hal::opamp::opamp1::IntoPga as _;
+use stm32g4xx_hal::opamp::opamp2::IntoPga as _;
+use stm32g4xx_hal::opamp::NonInvertingGain;
+use stm32g4xx_hal::opamp::PgaModeInternal;
+use stm32g4xx_hal::prelude::*;
+
+use utils::logger::info;
+
+#[macro_use]
+mod utils;
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    utils::logger::init();
+
+    // take peripherals
+    let dp = stm32g4xx_hal::stm32::Peripherals::take().unwrap();
+    let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
+
+    // setup clock
+    let config = stm32g4xx_hal::rcc::Config::hsi();
+    let mut rcc = dp.RCC.freeze(config);
+
+    // split gpio
+    let gpioa = dp.GPIOA.split(&mut rcc);
+    let gpiob = dp.GPIOB.split(&mut rcc);
+
+    // setup opamps
+    let (opamp1, opamp2, opamp3, opamp4, _opamp5, _opamp6) = dp.OPAMP.split(&mut rcc);
+
+    let opamp1 = opamp1.follower(gpioa.pa1, Some(gpioa.pa2));
+    let opamp2 = opamp2.follower(gpioa.pa7, Option::<PA6<Analog>>::None);
+
+    let opamp3 = opamp3.open_loop(gpiob.pb0, gpiob.pb2, Some(gpiob.pb1));
+    let opamp4 = opamp4.open_loop(gpiob.pb11, gpiob.pb10, Option::<PB12<Analog>>::None);
+
+    // disable opamps
+    let (opamp1, pa1, some_pa2) = opamp1.disable();
+    let (opamp2, pa7, _none) = opamp2.disable();
+
+    let (_opamp3, _pb0, _pb2, _some_pb1) = opamp3.disable();
+    let (_opamp4, _pb11, _pb10, _none) = opamp4.disable();
+
+    /*let _opamp1 = opamp1.pga(
+        pa1,
+        PgaModeInternal::gain(NonInvertingGain::Gain2),
+        some_pa2,
+    );*/
+    let mut opamp2 = opamp2.pga(
+        pa7,
+        PgaModeInternal::gain(NonInvertingGain::Gain4),
+        //Some(gpioa.pa6),
+        Option::<PA6<Analog>>::None,
+    );
+
+    let mut delay = cp.SYST.delay(&rcc.clocks);
+    let mut adc = dp
+        .ADC2
+        .claim(ClockSource::SystemClock, &rcc, &mut delay, true);
+
+    loop {
+        let sample = adc.convert(&mut opamp2, stm32g4xx_hal::adc::config::SampleTime::Cycles_640_5);
+
+        delay.delay_ms(100);
+
+        let millivolts = adc.sample_to_millivolts(sample);
+        info!("opamp2 thus 2x pa7: {}mV", millivolts);
+    }
+
+    #[allow(unreachable_code)]
+    {
+        //let (_opamp1, _pa1, _mode, _some_pa2) = _opamp1.disable();
+        let (_opamp2, _pa7, _mode, _none) = opamp2.disable();
+
+        loop {}
+    }
+}

--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -36,7 +36,7 @@ fn main() -> ! {
     let gpiob = dp.GPIOB.split(&mut rcc);
 
     // setup opamps
-    let (opamp1, opamp2, opamp3, opamp4, _opamp5, _opamp6) = dp.OPAMP.split(&mut rcc);
+    let (opamp1, opamp2, opamp3, opamp4, ..) = dp.OPAMP.split(&mut rcc);
 
     let opamp1 = opamp1.follower(gpioa.pa1, Some(gpioa.pa2));
     let opamp2 = opamp2.follower(gpioa.pa7, Option::<PA6<Analog>>::None);
@@ -51,11 +51,11 @@ fn main() -> ! {
     let (_opamp3, _pb0, _pb2, _some_pb1) = opamp3.disable();
     let (_opamp4, _pb11, _pb10, _none) = opamp4.disable();
 
-    /*let _opamp1 = opamp1.pga(
+    let _opamp1 = opamp1.pga(
         pa1,
         PgaModeInternal::gain(NonInvertingGain::Gain2),
         some_pa2,
-    );*/
+    );
     let mut opamp2 = opamp2.pga(
         pa7,
         PgaModeInternal::gain(NonInvertingGain::Gain4),
@@ -69,12 +69,13 @@ fn main() -> ! {
         .claim(ClockSource::SystemClock, &rcc, &mut delay, true);
 
     loop {
+        // Here we can sample the output of opamp2 as if it was a regular AD pin
         let sample = adc.convert(&mut opamp2, stm32g4xx_hal::adc::config::SampleTime::Cycles_640_5);
 
-        delay.delay_ms(100);
-
         let millivolts = adc.sample_to_millivolts(sample);
-        info!("opamp2 thus 2x pa7: {}mV", millivolts);
+        info!("opamp2 thus 4x pa7: {}mV", millivolts);
+
+        delay.delay_ms(100);
     }
 
     #[allow(unreachable_code)]

--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -38,9 +38,11 @@ fn main() -> ! {
     // setup opamps
     let (opamp1, opamp2, opamp3, opamp4, ..) = dp.OPAMP.split(&mut rcc);
 
+    // Set up opamp1 and opamp2 in follower mode
     let opamp1 = opamp1.follower(gpioa.pa1, Some(gpioa.pa2));
     let opamp2 = opamp2.follower(gpioa.pa7, Option::<PA6<Analog>>::None);
 
+    // Set up opamp1 and opamp2 in open loop mode
     let opamp3 = opamp3.open_loop(gpiob.pb0, gpiob.pb2, Some(gpiob.pb1));
     let opamp4 = opamp4.open_loop(gpiob.pb11, gpiob.pb10, Option::<PB12<Analog>>::None);
 
@@ -51,16 +53,19 @@ fn main() -> ! {
     let (_opamp3, _pb0, _pb2, _some_pb1) = opamp3.disable();
     let (_opamp4, _pb11, _pb10, _none) = opamp4.disable();
 
+    // Configure opamp1 with pa1 as non-inverting input and set gain to x2
     let _opamp1 = opamp1.pga(
         pa1,
         PgaModeInternal::gain(NonInvertingGain::Gain2),
-        some_pa2,
+        some_pa2, // Route output to pin pa2
     );
+
+    // Configure op with pa7 as non-inverting input and set gain to x4
     let mut opamp2 = opamp2.pga(
         pa7,
         PgaModeInternal::gain(NonInvertingGain::Gain4),
         //Some(gpioa.pa6),
-        Option::<PA6<Analog>>::None,
+        Option::<PA6<Analog>>::None, // Do not route output to any external pin, use internal AD instead
     );
 
     let mut delay = cp.SYST.delay(&rcc.clocks);
@@ -80,7 +85,7 @@ fn main() -> ! {
 
     #[allow(unreachable_code)]
     {
-        //let (_opamp1, _pa1, _mode, _some_pa2) = _opamp1.disable();
+        let (_opamp1, _pa1, _mode, _some_pa2) = _opamp1.disable();
         let (_opamp2, _pa7, _mode, _none) = opamp2.disable();
 
         loop {}

--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -6,7 +6,6 @@
 use stm32g4xx_hal::adc::AdcClaim;
 use stm32g4xx_hal::adc::ClockSource;
 use stm32g4xx_hal::gpio::gpioa::*;
-use stm32g4xx_hal::gpio::gpiob::*;
 use stm32g4xx_hal::gpio::Analog;
 use stm32g4xx_hal::opamp::opamp1::IntoPga as _;
 use stm32g4xx_hal::opamp::opamp2::IntoPga as _;
@@ -36,7 +35,7 @@ fn main() -> ! {
     let gpiob = dp.GPIOB.split(&mut rcc);
 
     // setup opamps
-    let (opamp1, opamp2, opamp3, opamp4, ..) = dp.OPAMP.split(&mut rcc);
+    let (opamp1, opamp2, opamp3, ..) = dp.OPAMP.split(&mut rcc);
 
     // Set up opamp1 and opamp2 in follower mode
     let opamp1 = opamp1.follower(gpioa.pa1, Some(gpioa.pa2));
@@ -44,14 +43,12 @@ fn main() -> ! {
 
     // Set up opamp1 and opamp2 in open loop mode
     let opamp3 = opamp3.open_loop(gpiob.pb0, gpiob.pb2, Some(gpiob.pb1));
-    let opamp4 = opamp4.open_loop(gpiob.pb11, gpiob.pb10, Option::<PB12<Analog>>::None);
 
     // disable opamps
     let (opamp1, pa1, some_pa2) = opamp1.disable();
     let (opamp2, pa7, _none) = opamp2.disable();
 
     let (_opamp3, _pb0, _pb2, _some_pb1) = opamp3.disable();
-    let (_opamp4, _pb11, _pb10, _none) = opamp4.disable();
 
     // Configure opamp1 with pa1 as non-inverting input and set gain to x2
     let _opamp1 = opamp1.pga(

--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -64,7 +64,6 @@ fn main() -> ! {
     let mut opamp2 = opamp2.pga(
         pa7,
         PgaModeInternal::gain(NonInvertingGain::Gain4),
-        //Some(gpioa.pa6),
         Option::<PA6<Analog>>::None, // Do not route output to any external pin, use internal AD instead
     );
 
@@ -75,7 +74,10 @@ fn main() -> ! {
 
     loop {
         // Here we can sample the output of opamp2 as if it was a regular AD pin
-        let sample = adc.convert(&mut opamp2, stm32g4xx_hal::adc::config::SampleTime::Cycles_640_5);
+        let sample = adc.convert(
+            &mut opamp2,
+            stm32g4xx_hal::adc::config::SampleTime::Cycles_640_5,
+        );
 
         let millivolts = adc.sample_to_millivolts(sample);
         info!("opamp2 thus 4x pa7: {}mV", millivolts);

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -13,9 +13,10 @@ pub use crate::time::U32Ext as _;
 use crate::{
     dma::{mux::DmaMuxResources, traits::TargetAddress, PeripheralToMemory},
     gpio::*,
+    opamp,
     rcc::{Enable, Rcc, Reset},
     signature::{VtempCal110, VtempCal30, VDDA_CALIB},
-    stm32, opamp,
+    stm32,
 };
 use core::fmt;
 use core::marker::PhantomData;

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -15,7 +15,7 @@ use crate::{
     gpio::*,
     rcc::{Enable, Rcc, Reset},
     signature::{VtempCal110, VtempCal30, VDDA_CALIB},
-    stm32,
+    stm32, opamp,
 };
 use core::fmt;
 use core::marker::PhantomData;
@@ -59,6 +59,17 @@ macro_rules! adc_pins {
     ($($pin:ty => ($adc:ident, $chan:expr)),+ $(,)*) => {
         $(
             impl Channel<stm32::$adc> for $pin {
+                type ID = u8;
+                fn channel() -> u8 { $chan }
+            }
+        )+
+    };
+}
+
+macro_rules! adc_op {
+    ($($opamp:ty => ($adc:ident, $chan:expr)),+ $(,)*) => {
+        $(
+            impl<A, B> Channel<stm32::$adc> for $opamp {
                 type ID = u8;
                 fn channel() -> u8 { $chan }
             }
@@ -2336,6 +2347,29 @@ adc_pins!(
     Vref => (ADC3, 18),
     Vref => (ADC4, 18),
     Vref => (ADC5, 18),
+);
+
+// See https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf#page=782
+#[cfg(any(
+    feature = "stm32g473",
+    feature = "stm32g474",
+    feature = "stm32g483",
+    feature = "stm32g484",
+))]
+adc_op!(
+    opamp::opamp1::Pga<A, B> => (ADC1, 3),
+
+    opamp::opamp2::Pga<A, B> => (ADC2, 3),
+
+    opamp::opamp3::Pga<A, B> => (ADC1, 12),
+
+    opamp::opamp4::Pga<A, B> => (ADC4, 3),
+    opamp::opamp4::Pga<A, B> => (ADC1, 11),
+
+    opamp::opamp5::Pga<A, B> => (ADC5, 1),
+
+    opamp::opamp6::Pga<A, B> => (ADC1, 14),
+    opamp::opamp6::Pga<A, B> => (ADC2, 14),
 );
 
 #[cfg(any(feature = "stm32g491", feature = "stm32g4a1",))]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -2357,6 +2357,9 @@ adc_pins!(
     feature = "stm32g484",
 ))]
 adc_op!(
+    // TODO: Add all opamp types: Follower, OpenLoop
+    // TODO: Should we restrict type parameters A and B?
+
     opamp::opamp1::Pga<A, B> => (ADC1, 3),
 
     opamp::opamp2::Pga<A, B> => (ADC2, 3),

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -2351,27 +2351,25 @@ adc_pins!(
 );
 
 // See https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf#page=782
+adc_op!(
+    // TODO: Add all opamp types: Follower, OpenLoop
+    // TODO: Should we restrict type parameters A and B?
+    // TODO: Also allow AD-channels shared by pins
+    opamp::opamp1::Pga<A, B> => (ADC1, 13),
+    opamp::opamp2::Pga<A, B> => (ADC2, 16),
+    opamp::opamp3::Pga<A, B> => (ADC2, 18),
+);
+
 #[cfg(any(
+    feature = "stm32g471",
     feature = "stm32g473",
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
 ))]
 adc_op!(
-    // TODO: Add all opamp types: Follower, OpenLoop
-    // TODO: Should we restrict type parameters A and B?
-    // TODO: Also allow AD-channels shared by pins
-
-    opamp::opamp1::Pga<A, B> => (ADC1, 13),
-
-    opamp::opamp2::Pga<A, B> => (ADC2, 16),
-
-    opamp::opamp3::Pga<A, B> => (ADC2, 18),
-
     opamp::opamp4::Pga<A, B> => (ADC5, 5),
-
     opamp::opamp5::Pga<A, B> => (ADC5, 3),
-
     opamp::opamp6::Pga<A, B> => (ADC4, 17),
 );
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -2361,7 +2361,6 @@ adc_op!(
 );
 
 #[cfg(any(
-    feature = "stm32g471",
     feature = "stm32g473",
     feature = "stm32g474",
     feature = "stm32g483",

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -2359,20 +2359,19 @@ adc_pins!(
 adc_op!(
     // TODO: Add all opamp types: Follower, OpenLoop
     // TODO: Should we restrict type parameters A and B?
+    // TODO: Also allow AD-channels shared by pins
 
-    opamp::opamp1::Pga<A, B> => (ADC1, 3),
+    opamp::opamp1::Pga<A, B> => (ADC1, 13),
 
-    opamp::opamp2::Pga<A, B> => (ADC2, 3),
+    opamp::opamp2::Pga<A, B> => (ADC2, 16),
 
-    opamp::opamp3::Pga<A, B> => (ADC1, 12),
+    opamp::opamp3::Pga<A, B> => (ADC2, 18),
 
-    opamp::opamp4::Pga<A, B> => (ADC4, 3),
-    opamp::opamp4::Pga<A, B> => (ADC1, 11),
+    opamp::opamp4::Pga<A, B> => (ADC5, 5),
 
-    opamp::opamp5::Pga<A, B> => (ADC5, 1),
+    opamp::opamp5::Pga<A, B> => (ADC5, 3),
 
-    opamp::opamp6::Pga<A, B> => (ADC1, 14),
-    opamp::opamp6::Pga<A, B> => (ADC2, 14),
+    opamp::opamp6::Pga<A, B> => (ADC4, 17),
 );
 
 #[cfg(any(feature = "stm32g491", feature = "stm32g4a1",))]

--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -119,6 +119,17 @@ macro_rules! opamps {
                         output: Option<$output>,
                     }
 
+                    pub enum NonInvertingGain {
+                        Gain2 = 0,
+                        Gain4 = 1,
+                        Gain8 = 2,
+                        Gain16 = 3,
+                        Gain32 = 4,
+                        Gain64 = 5
+                    }
+
+                    // TODO: Inverting gain
+
                     pub struct Config<MODE> {
                         mode: MODE,
                         pga_gain: crate::stm32::opamp::[<$opamp _csr>]::PGA_GAIN_A,
@@ -242,7 +253,7 @@ macro_rules! opamps {
 
                     opamps!{ @follower $opamp, $output, $($non_inverting_mask, $non_inverting),* }
                     opamps!{ @open_loop_tt $opamp, $output, $($non_inverting_mask, $non_inverting),* : ($($inverting_mask, $inverting),*) }
-                    opamps!{ @pga_tt $opamp, $output, $($non_inverting_mask, $non_inverting),* : ($($inverting_mask),*) }
+                    opamps!{ @pga_tt $opamp, $output, $($non_inverting_mask, $non_inverting),* : ($($inverting),*) }
                 }
             )*
 
@@ -417,11 +428,11 @@ macro_rules! opamps {
         ,
         $non_inverting:ty
         ,
-        ($($inverting_mask:tt,),*)
+        ($($invertings:ty),*)
     } => {
         paste::paste!{
-            $(impl <IntoNonInverting, MODE, IntoOutput> IntoPga
-                <IntoNonInverting, Config<MODE>, IntoOutput, $non_inverting> for Disabled
+            $(impl <IntoNonInverting, $mode, IntoOutput> IntoPga
+                <IntoNonInverting, Config<$mode>, IntoOutput, $non_inverting> for Disabled
                 where
                     IntoNonInverting: Into<$non_inverting>,
                     IntoOutput: Into<$output>,
@@ -429,7 +440,7 @@ macro_rules! opamps {
                 fn pga(
                     self,
                     non_inverting: IntoNonInverting,
-                    config: Config<MODE>,
+                    config: Config<$mode>,
                     output: Option<IntoOutput>,
                 ) -> Pga<$non_inverting, $config> {
                     let non_inverting = non_inverting.into();


### PR DESCRIPTION
Blocked on #72

This adds support for using op amp in programmable gain mode and also optionally routing its output direclty to an AD channe(without going to to an external pin). This enables use of opamp with minimal usage of external pins. For example only using 1 pin for non-inverting input:

```rust
let (opamp1, opamp2, opamp3, opamp4, ..) = dp.OPAMP.split(&mut rcc);

// Configure op with pa7 as non-inverting input and set gain to x4
let mut opamp2 = opamp2.pga(
    pa7,
    PgaModeInternal::gain(NonInvertingGain::Gain4),
    //Some(gpioa.pa6),
    Option::<PA6<Analog>>::None, // Do not route output to any external pin, use internal AD instead
);

let mut delay = cp.SYST.delay(&rcc.clocks);
let mut adc = dp
    .ADC2
    .claim(ClockSource::SystemClock, &rcc, &mut delay, true);

// Here we can sample the output of opamp2 as if it was a regular AD pin
let sample = adc.convert(&mut opamp2, stm32g4xx_hal::adc::config::SampleTime::Cycles_640_5);
let millivolts = adc.sample_to_millivolts(sample);
info!("opamp2 thus 4x pa7: {}mV", millivolts);
```

Tested on nucleo-g474re whith stm32g474re(with the commits from #73 for logging to work)