### PR TITLE
Hacky g491 and g4a1 support

### DIFF
--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -1,33 +1,50 @@
 #![no_main]
 #![no_std]
 
-use crate::hal::{
-    can::CanExt,
-    gpio::{GpioExt as _, Speed},
-    nb::block,
-    rcc::{Config, RccExt, SysClockSrc},
-    stm32::Peripherals,
-    time::U32Ext,
-};
-use fdcan::{
-    config::NominalBitTiming,
-    filter::{StandardFilter, StandardFilterSlot},
-    frame::{FrameFormat, TxFrameHeader},
-    id::StandardId,
-};
-use stm32g4xx_hal as hal;
-
-use core::num::{NonZeroU16, NonZeroU8};
-
-use cortex_m_rt::entry;
-
-use log::info;
-
+#[cfg(not(any(
+    feature = "stm32g491", // TODO: Make this work for these device too
+    feature = "stm32g4a1",
+)))]
 #[macro_use]
 mod utils;
 
+#[cfg(not(any(
+    feature = "stm32g491", // TODO: Make this work for these device too
+    feature = "stm32g4a1",
+)))]
 #[entry]
 fn main() -> ! {
+    loop {}
+}
+
+#[cfg(not(any(
+    feature = "stm32g491", // TODO: Make this work for these device too
+    feature = "stm32g4a1",
+)))]
+#[entry]
+fn main() -> ! {
+    use crate::hal::{
+        can::CanExt,
+        gpio::{GpioExt as _, Speed},
+        nb::block,
+        rcc::{Config, RccExt, SysClockSrc},
+        stm32::Peripherals,
+        time::U32Ext,
+    };
+    use fdcan::{
+        config::NominalBitTiming,
+        filter::{StandardFilter, StandardFilterSlot},
+        frame::{FrameFormat, TxFrameHeader},
+        id::StandardId,
+    };
+    use stm32g4xx_hal as hal;
+
+    use core::num::{NonZeroU16, NonZeroU8};
+
+    use cortex_m_rt::entry;
+
+    use log::info;
+
     utils::logger::init();
 
     info!("Start");

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -2180,8 +2180,8 @@ adc!(ADC2 => (configure_clock_source12, DmaMuxResources::ADC2, (ADC12_COMMON) ))
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
-    feature = "stm32g491",
-    feature = "stm32g4a1",
+    //feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+    //feature = "stm32g4a1", // datasheet says it should be there
 ))]
 adc!(ADC3 => (configure_clock_source345, DmaMuxResources::ADC3, (ADC345_COMMON) ));
 

--- a/src/can.rs
+++ b/src/can.rs
@@ -37,6 +37,10 @@ impl<FDCAN> Can<FDCAN> {
 }
 
 /// Extension trait for CAN controller
+#[cfg(not(any(
+    feature = "stm32g491", // TODO: Seems like the result of rcc.rb.ccipr.read().fdcansel(),
+    feature = "stm32g4a1", // does not have the method `is_hse` for g491 and g4a1
+)))]
 pub trait CanExt: Sized
 where
     Self: rcc::Instance,
@@ -139,8 +143,8 @@ mod fdcan1 {
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
-    feature = "stm32g491",
-    feature = "stm32g4A1",
+    //feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+    //feature = "stm32g4a1", // datasheet says it should be there
 ))]
 mod fdcan2 {
     use super::sealed;

--- a/src/fdcan.rs
+++ b/src/fdcan.rs
@@ -1713,8 +1713,8 @@ mod impls {
         feature = "stm32g474",
         feature = "stm32g483",
         feature = "stm32g484",
-        feature = "stm32g491",
-        feature = "stm32g4A1",
+        //feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+        //feature = "stm32g4a1", // datasheet says it should be there
     ))]
     mod fdcan2 {
         use crate::fdcan;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
+    feature = "stm32g491",
+    feature = "stm32g4a1",
 )))]
 
 compile_error!(
@@ -18,7 +20,9 @@ compile_error!(
         stm32g473
         stm32g474
         stm32g483
-        stm32g484"
+        stm32g484
+        stm32g491
+        stm32g4a1"
 );
 
 extern crate bare_metal;
@@ -57,11 +61,22 @@ pub use stm32g4::stm32g483 as stm32;
 #[cfg(feature = "stm32g484")]
 pub use stm32g4::stm32g484 as stm32;
 
+#[cfg(feature = "stm32g491")]
+pub use stm32g4::stm32g491 as stm32;
+
+#[cfg(feature = "stm32g4a1")]
+pub use stm32g4::stm32g4a1 as stm32;
+
 #[cfg(feature = "rt")]
 pub use crate::stm32::interrupt;
 
 pub mod adc;
 pub mod bb;
+
+#[cfg(not(any(
+    feature = "stm32g491", // TODO: Seems like the result of rcc.rb.ccipr.read().fdcansel(),
+    feature = "stm32g4a1", // does not have the method `is_hse` for g491 and g4a1
+)))]
 pub mod can;
 // pub mod crc;
 // pub mod dac;

--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -338,7 +338,6 @@ macro_rules! opamps {
     };
 }
 
-#[cfg(any(feature = "stm32g431", feature = "stm32g441", feature = "stm32g471",))]
 opamps! {
     opamp1: {
         inverting: {
@@ -386,43 +385,6 @@ opamps! {
     feature = "stm32g484",
 ))]
 opamps! {
-    opamp1: {
-        inverting: {
-            crate::gpio::gpioa::PA3<crate::gpio::Analog>: vinm0,
-            crate::gpio::gpioc::PC5<crate::gpio::Analog>: vinm1,
-        },
-        non_inverting: {
-            crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp0,
-            crate::gpio::gpioa::PA3<crate::gpio::Analog>: vinp1,
-            crate::gpio::gpioa::PA7<crate::gpio::Analog>: vinp2,
-        },
-        output: crate::gpio::gpioa::PA2<crate::gpio::Analog>,
-    },
-    opamp2: {
-        inverting: {
-            crate::gpio::gpioa::PA5<crate::gpio::Analog>: vinm0,
-            crate::gpio::gpioc::PC5<crate::gpio::Analog>: vinm1,
-        },
-        non_inverting: {
-            crate::gpio::gpioa::PA7<crate::gpio::Analog>: vinp0,
-            crate::gpio::gpiob::PB14<crate::gpio::Analog>: vinp1,
-            crate::gpio::gpiob::PB0<crate::gpio::Analog>: vinp2,
-            crate::gpio::gpiod::PD14<crate::gpio::Analog>: vinp3,
-        },
-        output: crate::gpio::gpioa::PA6<crate::gpio::Analog>,
-    },
-    opamp3: {
-        inverting: {
-            crate::gpio::gpiob::PB2<crate::gpio::Analog>: vinm0,
-            crate::gpio::gpiob::PB10<crate::gpio::Analog>: vinm1,
-        },
-        non_inverting: {
-            crate::gpio::gpiob::PB0<crate::gpio::Analog>: vinp0,
-            crate::gpio::gpiob::PB13<crate::gpio::Analog>: vinp1,
-            crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp2,
-        },
-        output: crate::gpio::gpiob::PB1<crate::gpio::Analog>,
-    },
     opamp4: {
         inverting: {
             crate::gpio::gpiob::PB10<crate::gpio::Analog>: vinm0,
@@ -447,6 +409,9 @@ opamps! {
         },
         output: crate::gpio::gpioa::PA8<crate::gpio::Analog>,
     },
+
+    // TODO: opamp 6 is available on all but g431/g441,
+    // see https://www.st.com/resource/en/reference_manual/rm0440-stm32g4-series-advanced-armbased-32bit-mcus-stmicroelectronics.pdf#page=75
     opamp6: {
         inverting: {
             crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinm0,

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -180,8 +180,8 @@ use crate::stm32::RCC;
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
-    feature = "stm32g491",
-    feature = "stm32g4A1"
+    //feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+    //feature = "stm32g4a1", // datasheet says it should be there
 ))]
 use crate::stm32::TIM20;
 #[cfg(any(
@@ -873,8 +873,8 @@ pins! {
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
-    feature = "stm32g491",
-    feature = "stm32g4A1"
+    //feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+    //feature = "stm32g4a1", // datasheet says it should be there
 ))]
 pins! {
     TIM20:
@@ -1477,8 +1477,8 @@ tim_hal! {
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
-    feature = "stm32g491",
-    feature = "stm32g4a1"
+    //feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+    //feature = "stm32g4a1", // datasheet says it should be there
 ))]
 tim_hal! {
     TIM20: (tim20, u16, 16, BDTR: bdtr, set_bit, af1, set_bit),
@@ -1754,8 +1754,8 @@ tim_pin_hal! {
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
-    feature = "stm32g491",
-    feature = "stm32g4A1"
+    //feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+    //feature = "stm32g4a1", // datasheet says it should be there
 ))]
 tim_pin_hal! {
     TIM20: (C1, cc1e, cc1p, ccmr1_output, oc1pe, oc1m, ccr1, u16, cc1ne, cc1np),

--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -82,7 +82,9 @@ bus! {
     feature = "stm32g473",
     feature = "stm32g474",
     feature = "stm32g483",
-    feature = "stm32g484"
+    feature = "stm32g484",
+    feature = "stm32g491",
+    feature = "stm32g4a1",
 ))]
 bus! {
     ADC3 => (AHB2, 14),
@@ -115,6 +117,14 @@ bus! {
     QUADSPI => (AHB3, 8),
 }
 
+#[cfg(not(any(
+    feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+    feature = "stm32g4a1", // datasheet says it should be there
+)))]
+bus! {
+    USB => (APB1_1, 23),
+}
+
 bus! {
     TIM2 => (APB1_1, 0),
     TIM3 => (APB1_1, 1),
@@ -129,7 +139,6 @@ bus! {
     UART4 => (APB1_1, 19),
     I2C1 => (APB1_1, 21),
     I2C2 => (APB1_1, 22),
-    USB => (APB1_1, 23),
     FDCAN1 => (APB1_1, 25),
     PWR => (APB1_1, 28),
     I2C3 => (APB1_1, 30),
@@ -144,11 +153,24 @@ bus! {
     feature = "stm32g474",
     feature = "stm32g483",
     feature = "stm32g484",
-    feature = "stm32g491",
-    feature = "stm32g4A1"
+    //feature = "stm32g491", // TODO: Seems to be missing in pac and svd,
+    //feature = "stm32g4a1", // datasheet says it should be there
 ))]
 bus! {
     FDCAN2 => (APB1_1, 25),
+}
+
+#[cfg(any(
+    feature = "stm32g471",
+    feature = "stm32g473",
+    feature = "stm32g474",
+    feature = "stm32g483",
+    feature = "stm32g484",
+    feature = "stm32g491",
+    feature = "stm32g4a1",
+))]
+bus! {
+    UART5 => (APB1_1, 20),
 }
 
 #[cfg(any(
@@ -160,7 +182,6 @@ bus! {
 ))]
 bus! {
     TIM5 => (APB1_1, 3),
-    UART5 => (APB1_1, 20),
     I2C4 => (APB1_2, 1),
 }
 


### PR DESCRIPTION
Tried to fix or mostly just disable the parts of the code that prevents this crate from compiling with `stm32g491` or `stm32g4a1`