### PR TITLE
OPAMP - Avoid overwriting rcc config of other modules

### DIFF
--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -209,7 +209,7 @@ macro_rules! opamps {
                 ) -> (
                     $($opamp::Disabled,)*
                 ) {
-                    rcc.rb.apb2enr.write(|w| w.syscfgen().set_bit());
+                    rcc.rb.apb2enr.modify(|_, w| w.syscfgen().set_bit());
 
                     (
                         $($opamp::Disabled,)*


### PR DESCRIPTION
I noticed that HRTIM stopped working when having a call `dp.OPAMP.split(&mut rcc);` after hrtim init. Turns out `OPAMP.split` overwrites the entire rcc apb2enr register