### PR TITLE
Fix use of depreciated `get_cycle_count` function

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -158,7 +158,7 @@ impl MonoTimer {
     /// Returns an `Instant` corresponding to "now"
     pub fn now(self) -> Instant {
         Instant {
-            now: DWT::get_cycle_count(),
+            now: DWT::cycle_count(),
         }
     }
 }
@@ -172,7 +172,7 @@ pub struct Instant {
 impl Instant {
     /// Ticks elapsed since the `Instant` was created
     pub fn elapsed(self) -> u32 {
-        DWT::get_cycle_count().wrapping_sub(self.now)
+        DWT::cycle_count().wrapping_sub(self.now)
     }
 }
 


### PR DESCRIPTION
Replaced with `cycle_count`.