### PR TITLE
Opamp - Pga does not need to own non-inverting input

### DIFF
--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -86,8 +86,8 @@ fn main() -> ! {
 
     #[allow(unreachable_code)]
     {
-        let (_opamp1, _pa1, _mode, _some_pa2) = _opamp1.disable();
-        let (_opamp2, _pa7, _mode, _none) = opamp2.disable();
+        let (_opamp1, _pa1, _mode) = _opamp1.disable();
+        let (_opamp2, _pa7, _mode) = opamp2.disable();
 
         loop {
             delay.delay_ms(100);


### PR DESCRIPTION
Some of the changes from my [messy branch](https://github.com/usbalbin/stm32g4xx-hal/commits/hrtim2). I will continue to try to extract digestable chunks from that branch to make PRs from if it is ok.