### PR TITLE
[(maybe?)DON'T MERGE] Update pac

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           - stm32g474
           - stm32g483
           - stm32g484
-          #- stm32g491 # Does not seem ready yet
-          #- stm32g4a1 # Does not seem ready yet
+          - stm32g491 # Does not seem ready yet
+          - stm32g4a1 # Does not seem ready yet
         features:
           - log-rtt,defmt
           # TODO: -log-rtt # log-rtt without defmt, more combos?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.0.2"
 
 [dependencies]
 nb = "0.1.1"
-stm32g4 = "0.15.1"
+stm32g4 = { git = "https://github.com/stm32-rs/stm32-rs-nightlies" } #"0.15.1"
 paste = "1.0"
 bitflags = "1.2"
 vcell = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ version = "0.0.2"
 
 [dependencies]
 nb = "0.1.1"
-stm32g4 = { git = "https://github.com/stm32-rs/stm32-rs-nightlies" } #"0.15.1"
+#stm32g4 = { git = "https://github.com/stm32-rs/stm32-rs-nightlies" } #"0.15.1"
+stm32g4 = { version = "0.17.0", package = "stm32g4-staging" }
 paste = "1.0"
 bitflags = "1.2"
 vcell = "0.1"

--- a/examples/flash_with_rtic.rs
+++ b/examples/flash_with_rtic.rs
@@ -73,7 +73,7 @@ mod app {
 
         unsafe {
             let mut flash = &(*stm32g4xx_hal::stm32::FLASH::ptr());
-            flash.acr.modify(|_, w| {
+            flash.acr().modify(|_, w| {
                 w.latency().bits(0b1000) // 8 wait states
             });
         }

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1301,7 +1301,7 @@ impl<ADC: TriggerType> Conversion<ADC> {
 ///
 ///     //Channel 1
 ///     //Disable the channel before configuring it
-///     tim.ccer.modify(|_, w| w.cc1e().clear_bit());
+///     tim.ccer().modify(|_, w| w.cc1e().clear_bit());
 ///
 ///     tim.ccmr1_output().modify(|_, w| w
 ///       //Preload enable for channel
@@ -1313,14 +1313,14 @@ impl<ADC: TriggerType> Conversion<ADC> {
 ///
 ///     //Set the duty cycle, 0 won't work in pwm mode but might be ok in
 ///     //toggle mode or match mode
-///     let max_duty = tim.arr.read().arr().bits() as u16;
-///     tim.ccr1.modify(|_, w| w.ccr().bits(max_duty / 2));
+///     let max_duty = tim.arr().read().arr().bits() as u16;
+///     tim.ccr1().modify(|_, w| w.ccr().bits(max_duty / 2));
 ///
 ///     //Enable the channel
-///     tim.ccer.modify(|_, w| w.cc1e().set_bit());
+///     tim.ccer().modify(|_, w| w.cc1e().set_bit());
 ///
 ///     //Enable the TIM main Output
-///     tim.bdtr.modify(|_, w| w.moe().set_bit());
+///     tim.bdtr().modify(|_, w| w.moe().set_bit());
 /// }
 /// ```
 #[derive(Clone, Copy)]
@@ -1413,7 +1413,7 @@ pub trait TriggerType {
 #[inline(always)]
 fn configure_clock_source12(cs: ClockSource, rcc: &Rcc) {
     // Select system clock as ADC clock source
-    rcc.rb.ccipr.modify(|_, w| {
+    rcc.rb.ccipr().modify(|_, w| {
         // This is sound, as `0b10` is a valid value for this field.
         unsafe {
             w.adc12sel().bits(cs.into());
@@ -1427,7 +1427,7 @@ fn configure_clock_source12(cs: ClockSource, rcc: &Rcc) {
 #[allow(dead_code)]
 fn configure_clock_source345(cs: ClockSource, rcc: &Rcc) {
     // Select system clock as ADC clock source
-    rcc.rb.ccipr.modify(|_, w| {
+    rcc.rb.ccipr().modify(|_, w| {
         // This is sound, as `0b10` is a valid value for this field.
         unsafe {
             w.adc345sel().bits(cs.into());
@@ -1608,21 +1608,21 @@ macro_rules! adc {
                 /// Enables the Deep Power Down Modus
                 #[inline(always)]
                 pub fn enable_deeppwd_down(&mut self) {
-                    self.adc_reg.cr.modify(|_, w| w.deeppwd().set_bit());
+                    self.adc_reg.cr().modify(|_, w| w.deeppwd().set_bit());
                 }
 
                 /// Disables the Deep Power Down Modus
                 #[inline(always)]
                 pub fn disable_deeppwd_down(&mut self) {
-                    self.adc_reg.cr.modify(|_, w| w.deeppwd().clear_bit());
+                    self.adc_reg.cr().modify(|_, w| w.deeppwd().clear_bit());
                 }
 
 
                 /// Enables the Voltage Regulator
                 #[inline(always)]
                 pub fn enable_vreg(&mut self, delay: &mut impl DelayUs<u8>) {
-                    self.adc_reg.cr.modify(|_, w| w.advregen().set_bit());
-                    while !self.adc_reg.cr.read().advregen().bit_is_set() {}
+                    self.adc_reg.cr().modify(|_, w| w.advregen().set_bit());
+                    while !self.adc_reg.cr().read().advregen().bit_is_set() {}
 
                     // According to the STM32G4xx Reference Manual, section 21.4.6, we need
                     // to wait for T_ADCVREG_STUP after enabling the internal voltage
@@ -1634,13 +1634,13 @@ macro_rules! adc {
                 /// Disables the Voltage Regulator
                 #[inline(always)]
                 pub fn disable_vreg(&mut self) {
-                    self.adc_reg.cr.modify(|_, w| w.advregen().clear_bit());
+                    self.adc_reg.cr().modify(|_, w| w.advregen().clear_bit());
                 }
 
                 /// Returns if the ADC is enabled (ADEN)
                 #[inline(always)]
                 pub fn is_enabled(&self) -> bool {
-                    self.adc_reg.cr.read().aden().bit_is_set()
+                    self.adc_reg.cr().read().aden().bit_is_set()
                 }
 
                 /// Disables the adc, since we don't know in what state we get it.
@@ -1650,11 +1650,11 @@ macro_rules! adc {
                     self.cancel_conversion();
 
                     // Turn off ADC
-                    self.adc_reg.cr.modify(|_, w| w.addis().set_bit());
-                    while self.adc_reg.cr.read().addis().bit_is_set() {}
+                    self.adc_reg.cr().modify(|_, w| w.addis().set_bit());
+                    while self.adc_reg.cr().read().addis().bit_is_set() {}
 
                     // Wait until the ADC has turned off
-                    while self.adc_reg.cr.read().aden().bit_is_set() {}
+                    while self.adc_reg.cr().read().aden().bit_is_set() {}
                 }
 
                 /// Enables the adc
@@ -1663,14 +1663,14 @@ macro_rules! adc {
                     self.calibrate_all();
                     self.apply_config(self.config);
 
-                    self.adc_reg.isr.modify(|_, w| w.adrdy().set_bit());
-                    self.adc_reg.cr.modify(|_, w| w.aden().set_bit());
+                    self.adc_reg.isr().modify(|_, w| w.adrdy().set_bit());
+                    self.adc_reg.cr().modify(|_, w| w.aden().set_bit());
 
                     // Wait for adc to get ready
-                    while !self.adc_reg.isr.read().adrdy().bit_is_set() {}
+                    while !self.adc_reg.isr().read().adrdy().bit_is_set() {}
 
                     // Clear ready flag
-                    self.adc_reg.isr.modify(|_, w| w.adrdy().set_bit());
+                    self.adc_reg.isr().modify(|_, w| w.adrdy().set_bit());
 
                     self.clear_end_of_conversion_flag();
                 }
@@ -1709,7 +1709,7 @@ macro_rules! adc {
                     self.config.clock_mode = clock_mode;
                     unsafe {
                         let common = &(*stm32::$common_type::ptr());
-                        common.ccr.modify(|_, w| w.ckmode().bits(clock_mode.into()));
+                        common.ccr().modify(|_, w| w.ckmode().bits(clock_mode.into()));
                     }
                 }
 
@@ -1719,7 +1719,7 @@ macro_rules! adc {
                     self.config.clock = clock;
                     unsafe {
                         let common = &(*stm32::$common_type::ptr());
-                        common.ccr.modify(|_, w| w.presc().bits(clock.into()));
+                        common.ccr().modify(|_, w| w.presc().bits(clock.into()));
                     }
                 }
 
@@ -1727,30 +1727,34 @@ macro_rules! adc {
                 #[inline(always)]
                 pub fn set_resolution(&mut self, resolution: config::Resolution) {
                     self.config.resolution = resolution;
-                    self.adc_reg.cfgr.modify(|_, w| w.res().bits(resolution.into()));
+                    unsafe {
+                        self.adc_reg.cfgr().modify(|_, w| w.res().bits(resolution.into()));
+                    }
                 }
 
 
                 /// Enable oversampling
                 #[inline(always)]
                 pub fn set_oversampling(&mut self, oversampling: config::OverSampling, shift: config::OverSamplingShift) {
-                    self.adc_reg.cfgr2.modify(|_, w| unsafe { w.ovsr().bits(oversampling.into())
-                                                      .ovss().bits(shift.into())
-                                                      .rovse().set_bit()});
+                    self.adc_reg.cfgr2().modify(|_, w| unsafe {
+                        w.ovsr().bits(oversampling.into())
+                            .ovss().bits(shift.into())
+                            .rovse().set_bit()
+                    });
                 }
 
                 /// Sets the DR register alignment to left or right
                 #[inline(always)]
                 pub fn set_align(&mut self, align: config::Align) {
                     self.config.align = align;
-                    self.adc_reg.cfgr.modify(|_, w| w.align().bit(align.into()));
+                    self.adc_reg.cfgr().modify(|_, w| w.align().bit(align.into()));
                 }
 
                 /// Sets which external trigger to use and if it is disabled, rising, falling or both
                 #[inline(always)]
                 pub fn set_external_trigger(&mut self, (edge, extsel): (config::TriggerMode, $trigger_type)) {
                     self.config.external_trigger = (edge, extsel);
-                    self.adc_reg.cfgr.modify(|_, w| unsafe { w
+                    self.adc_reg.cfgr().modify(|_, w| unsafe { w
                         .extsel().bits(extsel.into())
                         .exten().bits(edge.into())
                     });
@@ -1760,14 +1764,14 @@ macro_rules! adc {
                 #[inline(always)]
                 pub fn set_auto_delay(&mut self, delay: bool) {
                     self.config.auto_delay = delay;
-                    self.adc_reg.cfgr.modify(|_, w| w.autdly().bit(delay) );
+                    self.adc_reg.cfgr().modify(|_, w| w.autdly().bit(delay) );
                 }
 
                 /// Enables and disables dis-/continuous mode
                 #[inline(always)]
                 pub fn set_continuous(&mut self, continuous: config::Continuous) {
                     self.config.continuous = continuous;
-                    self.adc_reg.cfgr.modify(|_, w| w
+                    self.adc_reg.cfgr().modify(|_, w| w
                         .cont().bit(continuous == config::Continuous::Continuous)
                         .discen().bit(continuous == config::Continuous::Discontinuous)
                     );
@@ -1777,7 +1781,9 @@ macro_rules! adc {
                 // NOTE: The software is allowed to write these bits only when ADSTART = 0
                 fn set_subgroup_len(&mut self, subgroup_len: config::SubGroupLength) {
                     self.config.subgroup_len = subgroup_len;
-                    self.adc_reg.cfgr.modify(|_, w| w.discnum().bits(subgroup_len as u8))
+                    unsafe {
+                        self.adc_reg.cfgr().modify(|_, w| w.discnum().bits(subgroup_len as u8));
+                    }
                 }
 
                 /// Sets DMA to disabled, single or continuous
@@ -1789,7 +1795,7 @@ macro_rules! adc {
                         config::Dma::Single => (false, true),
                         config::Dma::Continuous => (true, true),
                     };
-                    self.adc_reg.cfgr.modify(|_, w| w
+                    self.adc_reg.cfgr().modify(|_, w| w
                         //DDS stands for "DMA disable selection"
                         //0 means do one DMA then stop
                         //1 means keep sending DMA requests as long as DMA=1
@@ -1808,7 +1814,7 @@ macro_rules! adc {
                         config::Eoc::Conversion => (true, true),
                         config::Eoc::Sequence => (true, false),
                     };
-                    self.adc_reg.ier.modify(|_, w|w
+                    self.adc_reg.ier().modify(|_, w|w
                         .eosie().bit(eocs)
                         .eocie().bit(en)
                     );
@@ -1818,7 +1824,7 @@ macro_rules! adc {
                 ///
                 /// This is triggered when the AD finishes a conversion before the last value was read by CPU/DMA
                 pub fn set_overrun_interrupt(&mut self, enable: bool) {
-                    self.adc_reg.ier.modify(|_, w| w.ovrie().bit(enable));
+                    self.adc_reg.ier().modify(|_, w| w.ovrie().bit(enable));
                 }
 
                 /// Sets the default sample time that is used for one-shot conversions.
@@ -1834,7 +1840,7 @@ macro_rules! adc {
                 pub fn set_channel_input_type(&mut self, df: config::DifferentialSelection) {
                     self.config.difsel = df;
 
-                    self.adc_reg.difsel.modify(|_, w| {w
+                    self.adc_reg.difsel().modify(|_, w| {w
                         .difsel_0().bit(df.get_channel(0).into() )
                         .difsel_1().bit(df.get_channel(1).into() )
                         .difsel_2().bit(df.get_channel(2).into() )
@@ -1861,19 +1867,19 @@ macro_rules! adc {
                 #[inline(always)]
                 pub fn reset_sequence(&mut self) {
                     //The reset state is One conversion selected
-                    self.adc_reg.sqr1.modify(|_, w| w.l().bits(config::Sequence::One.into()));
+                    self.adc_reg.sqr1().modify(|_, w| unsafe { w.l().bits(config::Sequence::One.into()) });
                 }
 
                 /// Returns the current sequence length. Primarily useful for configuring DMA.
                 #[inline(always)]
                 pub fn sequence_length(&mut self) -> u8 {
-                    self.adc_reg.sqr1.read().l().bits() + 1
+                    self.adc_reg.sqr1().read().l().bits() + 1
                 }
 
                 /// Returns the address of the ADC data register. Primarily useful for configuring DMA.
                 #[inline(always)]
                 pub fn data_register_address(&self) -> u32 {
-                    &self.adc_reg.dr as *const _ as u32
+                    &self.adc_reg.dr() as *const _ as u32
                 }
 
                 /// Calibrate the adc for <Input Type>
@@ -1881,15 +1887,15 @@ macro_rules! adc {
                 pub fn calibrate(&mut self, it: config::InputType) {
                     match it {
                         config::InputType::SingleEnded => {
-                            self.adc_reg.cr.modify(|_, w| w.adcaldif().clear_bit() );
+                            self.adc_reg.cr().modify(|_, w| w.adcaldif().clear_bit() );
                         },
                         config::InputType::Differential => {
-                            self.adc_reg.cr.modify(|_, w| w.adcaldif().set_bit() );
+                            self.adc_reg.cr().modify(|_, w| w.adcaldif().set_bit() );
                         },
                     }
 
-                    self.adc_reg.cr.modify(|_, w| w.adcal().set_bit() );
-                    while self.adc_reg.cr.read().adcal().bit_is_set() {}
+                    self.adc_reg.cr().modify(|_, w| w.adcal().set_bit() );
+                    while self.adc_reg.cr().read().adcal().bit_is_set() {}
                 }
 
                 /// Calibrate the Adc for all Input Types
@@ -1912,7 +1918,7 @@ macro_rules! adc {
                 {
 
                     //Check the sequence is long enough
-                    self.adc_reg.sqr1.modify(|r, w| {
+                    self.adc_reg.sqr1().modify(|r, w| unsafe {
                         let prev: config::Sequence = r.l().bits().into();
                         if prev < sequence {
                             w.l().bits(sequence.into())
@@ -1925,47 +1931,49 @@ macro_rules! adc {
 
                     //Set the channel in the right sequence field
                     match sequence {
-                        config::Sequence::One      => self.adc_reg.sqr1.modify(|_, w| unsafe {w.sq1().bits(channel) }),
-                        config::Sequence::Two      => self.adc_reg.sqr1.modify(|_, w| unsafe {w.sq2().bits(channel) }),
-                        config::Sequence::Three    => self.adc_reg.sqr1.modify(|_, w| unsafe {w.sq3().bits(channel) }),
-                        config::Sequence::Four     => self.adc_reg.sqr1.modify(|_, w| unsafe {w.sq4().bits(channel) }),
-                        config::Sequence::Five     => self.adc_reg.sqr2.modify(|_, w| unsafe {w.sq5().bits(channel) }),
-                        config::Sequence::Six      => self.adc_reg.sqr2.modify(|_, w| unsafe {w.sq6().bits(channel) }),
-                        config::Sequence::Seven    => self.adc_reg.sqr2.modify(|_, w| unsafe {w.sq7().bits(channel) }),
-                        config::Sequence::Eight    => self.adc_reg.sqr2.modify(|_, w| unsafe {w.sq8().bits(channel) }),
-                        config::Sequence::Nine     => self.adc_reg.sqr2.modify(|_, w| unsafe {w.sq9().bits(channel) }),
-                        config::Sequence::Ten      => self.adc_reg.sqr3.modify(|_, w| unsafe {w.sq10().bits(channel) }),
-                        config::Sequence::Eleven   => self.adc_reg.sqr3.modify(|_, w| unsafe {w.sq11().bits(channel) }),
-                        config::Sequence::Twelve   => self.adc_reg.sqr3.modify(|_, w| unsafe {w.sq12().bits(channel) }),
-                        config::Sequence::Thirteen => self.adc_reg.sqr3.modify(|_, w| unsafe {w.sq13().bits(channel) }),
-                        config::Sequence::Fourteen => self.adc_reg.sqr3.modify(|_, w| unsafe {w.sq14().bits(channel) }),
-                        config::Sequence::Fifteen  => self.adc_reg.sqr4.modify(|_, w| unsafe {w.sq15().bits(channel) }),
-                        config::Sequence::Sixteen  => self.adc_reg.sqr4.modify(|_, w| unsafe {w.sq16().bits(channel) }),
+                        config::Sequence::One      => self.adc_reg.sqr1().modify(|_, w| unsafe {w.sq1().bits(channel) }),
+                        config::Sequence::Two      => self.adc_reg.sqr1().modify(|_, w| unsafe {w.sq2().bits(channel) }),
+                        config::Sequence::Three    => self.adc_reg.sqr1().modify(|_, w| unsafe {w.sq3().bits(channel) }),
+                        config::Sequence::Four     => self.adc_reg.sqr1().modify(|_, w| unsafe {w.sq4().bits(channel) }),
+                        config::Sequence::Five     => self.adc_reg.sqr2().modify(|_, w| unsafe {w.sq5().bits(channel) }),
+                        config::Sequence::Six      => self.adc_reg.sqr2().modify(|_, w| unsafe {w.sq6().bits(channel) }),
+                        config::Sequence::Seven    => self.adc_reg.sqr2().modify(|_, w| unsafe {w.sq7().bits(channel) }),
+                        config::Sequence::Eight    => self.adc_reg.sqr2().modify(|_, w| unsafe {w.sq8().bits(channel) }),
+                        config::Sequence::Nine     => self.adc_reg.sqr2().modify(|_, w| unsafe {w.sq9().bits(channel) }),
+                        config::Sequence::Ten      => self.adc_reg.sqr3().modify(|_, w| unsafe {w.sq10().bits(channel) }),
+                        config::Sequence::Eleven   => self.adc_reg.sqr3().modify(|_, w| unsafe {w.sq11().bits(channel) }),
+                        config::Sequence::Twelve   => self.adc_reg.sqr3().modify(|_, w| unsafe {w.sq12().bits(channel) }),
+                        config::Sequence::Thirteen => self.adc_reg.sqr3().modify(|_, w| unsafe {w.sq13().bits(channel) }),
+                        config::Sequence::Fourteen => self.adc_reg.sqr3().modify(|_, w| unsafe {w.sq14().bits(channel) }),
+                        config::Sequence::Fifteen  => self.adc_reg.sqr4().modify(|_, w| unsafe {w.sq15().bits(channel) }),
+                        config::Sequence::Sixteen  => self.adc_reg.sqr4().modify(|_, w| unsafe {w.sq16().bits(channel) }),
                     }
 
                     //Set the sample time for the channel
                     let st = u8::from(sample_time);
-                    match channel {
-                        0 => self.adc_reg.smpr1.modify(|_, w| w.smp0().bits(st) ),
-                        1 => self.adc_reg.smpr1.modify(|_, w| w.smp1().bits(st) ),
-                        2 => self.adc_reg.smpr1.modify(|_, w| w.smp2().bits(st) ),
-                        3 => self.adc_reg.smpr1.modify(|_, w| w.smp3().bits(st) ),
-                        4 => self.adc_reg.smpr1.modify(|_, w| w.smp4().bits(st) ),
-                        5 => self.adc_reg.smpr1.modify(|_, w| w.smp5().bits(st) ),
-                        6 => self.adc_reg.smpr1.modify(|_, w| w.smp6().bits(st) ),
-                        7 => self.adc_reg.smpr1.modify(|_, w| w.smp7().bits(st) ),
-                        8 => self.adc_reg.smpr1.modify(|_, w| w.smp8().bits(st) ),
-                        9 => self.adc_reg.smpr1.modify(|_, w| w.smp9().bits(st) ),
-                        10 => self.adc_reg.smpr2.modify(|_, w| w.smp10().bits(st) ),
-                        11 => self.adc_reg.smpr2.modify(|_, w| w.smp11().bits(st) ),
-                        12 => self.adc_reg.smpr2.modify(|_, w| w.smp12().bits(st) ),
-                        13 => self.adc_reg.smpr2.modify(|_, w| w.smp13().bits(st) ),
-                        14 => self.adc_reg.smpr2.modify(|_, w| w.smp14().bits(st) ),
-                        15 => self.adc_reg.smpr2.modify(|_, w| w.smp15().bits(st) ),
-                        16 => self.adc_reg.smpr2.modify(|_, w| w.smp16().bits(st) ),
-                        17 => self.adc_reg.smpr2.modify(|_, w| w.smp17().bits(st) ),
-                        18 => self.adc_reg.smpr2.modify(|_, w| w.smp18().bits(st) ),
-                        _ => unimplemented!(),
+                    unsafe {
+                        match channel {
+                            0 => self.adc_reg.smpr1().modify(|_, w| w.smp0().bits(st) ),
+                            1 => self.adc_reg.smpr1().modify(|_, w| w.smp1().bits(st) ),
+                            2 => self.adc_reg.smpr1().modify(|_, w| w.smp2().bits(st) ),
+                            3 => self.adc_reg.smpr1().modify(|_, w| w.smp3().bits(st) ),
+                            4 => self.adc_reg.smpr1().modify(|_, w| w.smp4().bits(st) ),
+                            5 => self.adc_reg.smpr1().modify(|_, w| w.smp5().bits(st) ),
+                            6 => self.adc_reg.smpr1().modify(|_, w| w.smp6().bits(st) ),
+                            7 => self.adc_reg.smpr1().modify(|_, w| w.smp7().bits(st) ),
+                            8 => self.adc_reg.smpr1().modify(|_, w| w.smp8().bits(st) ),
+                            9 => self.adc_reg.smpr1().modify(|_, w| w.smp9().bits(st) ),
+                            10 => self.adc_reg.smpr2().modify(|_, w| w.smp10().bits(st) ),
+                            11 => self.adc_reg.smpr2().modify(|_, w| w.smp11().bits(st) ),
+                            12 => self.adc_reg.smpr2().modify(|_, w| w.smp12().bits(st) ),
+                            13 => self.adc_reg.smpr2().modify(|_, w| w.smp13().bits(st) ),
+                            14 => self.adc_reg.smpr2().modify(|_, w| w.smp14().bits(st) ),
+                            15 => self.adc_reg.smpr2().modify(|_, w| w.smp15().bits(st) ),
+                            16 => self.adc_reg.smpr2().modify(|_, w| w.smp16().bits(st) ),
+                            17 => self.adc_reg.smpr2().modify(|_, w| w.smp17().bits(st) ),
+                            18 => self.adc_reg.smpr2().modify(|_, w| w.smp18().bits(st) ),
+                            _ => unimplemented!(),
+                        }
                     }
                 }
                 /// Synchronously convert a single sample
@@ -1975,12 +1983,14 @@ macro_rules! adc {
                     PIN: Channel<stm32::$adc_type, ID=u8>
                 {
                     let saved_config = self.config;
-                    self.adc_reg.cfgr.modify(|_, w| w
-                        .dmaen().clear_bit() //Disable dma
-                        .cont().clear_bit() //Disable continuous mode
-                        .exten().bits(config::TriggerMode::Disabled.into()) //Disable trigger
-                    );
-                    self.adc_reg.ier.modify(|_, w| w
+                    unsafe {
+                        self.adc_reg.cfgr().modify(|_, w| w
+                            .dmaen().clear_bit() //Disable dma
+                            .cont().clear_bit() //Disable continuous mode
+                            .exten().bits(config::TriggerMode::Disabled.into()) //Disable trigger
+                        );
+                    }
+                    self.adc_reg.ier().modify(|_, w| w
                         .eocie().clear_bit() //Disable end of conversion interrupt
                     );
 
@@ -2005,116 +2015,116 @@ macro_rules! adc {
                 /// Resets the end-of-conversion flag
                 #[inline(always)]
                 pub fn clear_end_of_conversion_flag(&mut self) {
-                    self.adc_reg.isr.modify(|_, w| w.eoc().set_bit());
+                    self.adc_reg.isr().modify(|_, w| w.eoc().set_bit());
                 }
 
                 /// Block until the conversion is completed and return to configured
                 pub fn wait_for_conversion_sequence(&mut self) {
-                    while !self.adc_reg.isr.read().eoc().bit_is_set() {}
+                    while !self.adc_reg.isr().read().eoc().bit_is_set() {}
                 }
 
                 /// get current sample
                 #[inline(always)]
                 pub fn current_sample(&self) -> u16 {
-                    self.adc_reg.dr.read().rdata().bits()
+                    self.adc_reg.dr().read().rdata().bits()
                 }
 
                 /// Starts conversion sequence. Waits for the hardware to indicate it's actually started.
                 #[inline(always)]
                 pub fn start_conversion(&mut self) {
                     //Start conversion
-                    self.adc_reg.cr.modify(|_, w| w.adstart().set_bit());
+                    self.adc_reg.cr().modify(|_, w| w.adstart().set_bit());
                 }
 
                 /// Cancels an ongoing conversion
                 #[inline(always)]
                 pub fn cancel_conversion(&mut self) {
-                    self.adc_reg.cr.modify(|_, w| w.adstp().set_bit());
-                    while self.adc_reg.cr.read().adstart().bit_is_set() {}
+                    self.adc_reg.cr().modify(|_, w| w.adstp().set_bit());
+                    while self.adc_reg.cr().read().adstart().bit_is_set() {}
                 }
 
                 /// Returns if the Voltage Regulator is enabled
                 #[inline(always)]
                 pub fn is_vreg_enabled(&self) -> bool {
-                    self.adc_reg.cr.read().advregen().bit_is_set()
+                    self.adc_reg.cr().read().advregen().bit_is_set()
                 }
 
                 /// Returns if Deep Power Down is enabled
                 #[inline(always)]
                 pub fn is_deeppwd_enabled(&self) -> bool {
-                    self.adc_reg.cr.read().deeppwd().bit_is_set()
+                    self.adc_reg.cr().read().deeppwd().bit_is_set()
                 }
 
                 /// Returns if a conversion is active
                 #[inline(always)]
                 pub fn is_conversion_active(&self) -> bool {
-                    self.adc_reg.cr.read().adstart().bit_is_set()
+                    self.adc_reg.cr().read().adstart().bit_is_set()
                 }
 
                 /// Enables the vbat internal channel
                 #[inline(always)]
                 pub fn enable_vbat(&self, common: &stm32::$common_type) {
-                    common.ccr.modify(|_, w| w.vbatsel().set_bit());
+                    common.ccr().modify(|_, w| w.vbatsel().set_bit());
                 }
 
                 /// Enables the vbat internal channel
                 #[inline(always)]
                 pub fn disable_vbat(&self, common: &stm32::$common_type) {
-                    common.ccr.modify(|_, w| w.vbatsel().clear_bit());
+                    common.ccr().modify(|_, w| w.vbatsel().clear_bit());
                 }
 
                 /// Returns if the vbat internal channel is enabled
                 #[inline(always)]
                 pub fn is_vbat_enabled(&mut self, common: &stm32::$common_type) -> bool {
-                    common.ccr.read().vbatsel().bit_is_set()
+                    common.ccr().read().vbatsel().bit_is_set()
                 }
 
                 /// Enables the temp internal channel.
                 #[inline(always)]
                 pub fn enable_temperature(&mut self, common: &stm32::$common_type) {
-                    common.ccr.modify(|_, w| w.vsensesel().set_bit());
+                    common.ccr().modify(|_, w| w.vsensesel().set_bit());
                 }
 
                 /// Disables the temp internal channel
                 #[inline(always)]
                 pub fn disable_temperature(&mut self, common: &stm32::$common_type) {
-                    common.ccr.modify(|_, w| w.vsensesel().clear_bit());
+                    common.ccr().modify(|_, w| w.vsensesel().clear_bit());
                 }
 
                 /// Returns if the temp internal channel is enabled
                 #[inline(always)]
                 pub fn is_temperature_enabled(&mut self, common: &stm32::$common_type) -> bool {
-                    common.ccr.read().vsensesel().bit_is_set()
+                    common.ccr().read().vsensesel().bit_is_set()
                 }
 
                 /// Enables the vref internal channel.
                 #[inline(always)]
                 pub fn enable_vref(&mut self, common: &stm32::$common_type) {
-                    common.ccr.modify(|_, w| w.vrefen().set_bit());
+                    common.ccr().modify(|_, w| w.vrefen().set_bit());
                 }
 
                 /// Disables the vref internal channel
                 #[inline(always)]
                 pub fn disable_vref(&mut self, common: &stm32::$common_type) {
-                    common.ccr.modify(|_, w| w.vrefen().clear_bit());
+                    common.ccr().modify(|_, w| w.vrefen().clear_bit());
                 }
 
                 /// Returns if the vref internal channel is enabled
                 #[inline(always)]
                 pub fn is_vref_enabled(&mut self, common: &stm32::$common_type) -> bool {
-                    common.ccr.read().vrefen().bit_is_set()
+                    common.ccr().read().vrefen().bit_is_set()
                 }
 
                 /// Read overrun flag
                 #[inline(always)]
                 pub fn get_overrun_flag(&self) -> bool {
-                    self.adc_reg.isr.read().ovr().bit()
+                    self.adc_reg.isr().read().ovr().bit()
                 }
 
                 /// Resets the overrun flag
                 #[inline(always)]
                 pub fn clear_overrun_flag(&mut self) {
-                    self.adc_reg.isr.modify(|_, w| w.ovr().set_bit());
+                    self.adc_reg.isr().modify(|_, w| w.ovr().set_bit());
                 }
             }
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -2844,6 +2844,15 @@ adc_opamp!(
 ))]
 adc_opamp!(
     opamp::Opamp3 => (ADC3, 13),
+);
+
+#[cfg(any(
+    feature = "stm32g473",
+    feature = "stm32g474",
+    feature = "stm32g483",
+    feature = "stm32g484",
+))]
+adc_opamp!(
     opamp::Opamp4 => (ADC5, 5),
     opamp::Opamp5 => (ADC5, 3),
     opamp::Opamp6 => (ADC4, 17),

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1947,7 +1947,7 @@ macro_rules! adc {
                         config::Sequence::Fourteen => self.adc_reg.sqr3().modify(|_, w| unsafe {w.sq14().bits(channel) }),
                         config::Sequence::Fifteen  => self.adc_reg.sqr4().modify(|_, w| unsafe {w.sq15().bits(channel) }),
                         config::Sequence::Sixteen  => self.adc_reg.sqr4().modify(|_, w| unsafe {w.sq16().bits(channel) }),
-                    }
+                    };
 
                     //Set the sample time for the channel
                     let st = u8::from(sample_time);
@@ -1973,7 +1973,7 @@ macro_rules! adc {
                             17 => self.adc_reg.smpr2().modify(|_, w| w.smp17().bits(st) ),
                             18 => self.adc_reg.smpr2().modify(|_, w| w.smp18().bits(st) ),
                             _ => unimplemented!(),
-                        }
+                        };
                     }
                 }
                 /// Synchronously convert a single sample

--- a/src/can.rs
+++ b/src/can.rs
@@ -55,9 +55,9 @@ where
     {
         Self::enable(&rcc.rb);
 
-        if rcc.rb.ccipr.read().fdcansel().is_hse() {
+        if rcc.rb.ccipr().read().fdcansel().is_hse() {
             // Select P clock as FDCAN clock source
-            rcc.rb.ccipr.modify(|_, w| {
+            rcc.rb.ccipr().modify(|_, w| {
                 // This is sound, as `FdCanClockSource` only contains valid values for this field.
                 unsafe {
                     w.fdcansel().bits(FdCanClockSource::PCLK as u8);

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -55,26 +55,26 @@ impl EnabledState for Enabled {}
 impl EnabledState for Locked {}
 
 macro_rules! impl_comp {
-    ($($t:ident: $reg_t:ident, $reg:ident,)+) => {$(
+    ($($t:ident: $reg:ident,)+) => {$(
         pub struct $t {
             _rb: PhantomData<()>,
         }
 
         impl $t {
-            pub fn csr(&self) -> &$crate::stm32::comp::$reg_t {
+            pub fn csr(&self) -> &$crate::stm32::comp::CCSR {
                 // SAFETY: The COMP1 type is only constructed with logical ownership of
                 // these registers.
-                &unsafe { &*COMP::ptr() }.$reg
+                &unsafe { &*COMP::ptr() }.$reg()
             }
         }
     )+};
 }
 
 impl_comp! {
-    COMP1: C1CSR, c1csr,
-    COMP2: C2CSR, c2csr,
-    COMP3: C3CSR, c3csr,
-    COMP4: C4CSR, c4csr,
+    COMP1: c1csr,
+    COMP2: c2csr,
+    COMP3: c3csr,
+    COMP4: c4csr,
 }
 #[cfg(any(
     feature = "stm32g473",
@@ -83,9 +83,9 @@ impl_comp! {
     feature = "stm32g484"
 ))]
 impl_comp! {
-    COMP5: C5CSR, c5csr,
-    COMP6: C6CSR, c6csr,
-    COMP7: C7CSR, c7csr,
+    COMP5: c5csr,
+    COMP6: c6csr,
+    COMP7: c7csr,
 }
 
 // TODO: Split COMP in PAC
@@ -541,11 +541,11 @@ type Comparators = (COMP1, COMP2, COMP3, COMP4, COMP5, COMP6, COMP7);
 /// Enables the comparator peripheral, and splits the [`COMP`] into independent [`COMP1`] and [`COMP2`]
 pub fn split(_comp: COMP, rcc: &mut Rcc) -> Comparators {
     // Enable COMP, SYSCFG, VREFBUF clocks
-    rcc.rb.apb2enr.modify(|_, w| w.syscfgen().set_bit());
+    rcc.rb.apb2enr().modify(|_, w| w.syscfgen().set_bit());
 
     // Reset COMP, SYSCFG, VREFBUF
-    rcc.rb.apb2rstr.modify(|_, w| w.syscfgrst().set_bit());
-    rcc.rb.apb2rstr.modify(|_, w| w.syscfgrst().clear_bit());
+    rcc.rb.apb2rstr().modify(|_, w| w.syscfgrst().set_bit());
+    rcc.rb.apb2rstr().modify(|_, w| w.syscfgrst().clear_bit());
 
     (
         COMP1 { _rb: PhantomData },

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -162,13 +162,13 @@ macro_rules! positive_input_pin {
     ($COMP:ident, $pin_0:ident, $pin_1:ident) => {
         impl PositiveInput<$COMP> for &$pin_0<Analog> {
             fn setup(&self, comp: &$COMP) {
-                comp.csr().modify(|_, w| w.inpsel().bit(false))
+                comp.csr().modify(|_, w| w.inpsel().bit(false));
             }
         }
 
         impl PositiveInput<$COMP> for &$pin_1<Analog> {
             fn setup(&self, comp: &$COMP) {
-                comp.csr().modify(|_, w| w.inpsel().bit(true))
+                comp.csr().modify(|_, w| w.inpsel().bit(true));
             }
         }
     };
@@ -213,7 +213,7 @@ macro_rules! negative_input_pin_helper {
             }
 
             fn setup(&self, comp: &$COMP) {
-                comp.csr().modify(|_, w| unsafe { w.inmsel().bits($bits) })
+                comp.csr().modify(|_, w| unsafe { w.inmsel().bits($bits) });
             }
         }
     };
@@ -268,7 +268,7 @@ macro_rules! refint_input {
 
             fn setup(&self, comp: &$COMP) {
                 comp.csr()
-                    .modify(|_, w| unsafe { w.inmsel().bits(*self as u8) })
+                    .modify(|_, w| unsafe { w.inmsel().bits(*self as u8) });
             }
         }
     )+};
@@ -294,7 +294,7 @@ macro_rules! dac_input_helper {
             }
 
             fn setup(&self, comp: &$COMP) {
-                comp.csr().modify(|_, w| unsafe { w.inmsel().bits($bits) })
+                comp.csr().modify(|_, w| unsafe { w.inmsel().bits($bits) });
             }
         }
     };

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -179,7 +179,7 @@ macro_rules! dac_helper {
         $trim:ident,
         $mode:ident,
         $dhrx:ident,
-        $dac_dor:ident,
+        $dor:ident,
         $daccxdhr:ident,
         $wave:ident,
         $mamp:ident,
@@ -193,8 +193,8 @@ macro_rules! dac_helper {
                 pub fn enable(self) -> $CX<MODE_BITS, Enabled> {
                     let dac = unsafe { &(*<$DAC>::ptr()) };
 
-                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(MODE_BITS) });
-                    dac.dac_cr.modify(|_, w| w.$en().set_bit());
+                    dac.mcr().modify(|_, w| unsafe { w.$mode().bits(MODE_BITS) });
+                    dac.cr().modify(|_, w| w.$en().set_bit());
 
                     $CX {
                         _enabled: PhantomData,
@@ -204,8 +204,8 @@ macro_rules! dac_helper {
                 pub fn enable_generator(self, config: GeneratorConfig) -> $CX<MODE_BITS, WaveGenerator> {
                     let dac = unsafe { &(*<$DAC>::ptr()) };
 
-                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(MODE_BITS) });
-                    dac.dac_cr.modify(|_, w| unsafe {
+                    dac.mcr().modify(|_, w| unsafe { w.$mode().bits(MODE_BITS) });
+                    dac.cr().modify(|_, w| unsafe {
                         w.$wave().bits(config.mode);
                         w.$ten().set_bit();
                         w.$mamp().bits(config.amp);
@@ -235,19 +235,19 @@ macro_rules! dac_helper {
                     T: DelayUs<u32>,
                 {
                     let dac = unsafe { &(*<$DAC>::ptr()) };
-                    dac.dac_cr.modify(|_, w| w.$en().clear_bit());
-                    dac.dac_mcr.modify(|_, w| unsafe { w.$mode().bits(0) });
-                    dac.dac_cr.modify(|_, w| w.$cen().set_bit());
+                    dac.cr().modify(|_, w| w.$en().clear_bit());
+                    dac.mcr().modify(|_, w| unsafe { w.$mode().bits(0) });
+                    dac.cr().modify(|_, w| w.$cen().set_bit());
                     let mut trim = 0;
                     while true {
-                        dac.dac_ccr.modify(|_, w| unsafe { w.$trim().bits(trim) });
+                        dac.ccr().modify(|_, w| unsafe { w.$trim().bits(trim) });
                         delay.delay_us(64_u32);
-                        if dac.dac_sr.read().$cal_flag().bit() {
+                        if dac.sr().read().$cal_flag().bit() {
                             break;
                         }
                         trim += 1;
                     }
-                    dac.dac_cr.modify(|_, w| w.$cen().clear_bit());
+                    dac.cr().modify(|_, w| w.$cen().clear_bit());
 
                     $CX {
                         _enabled: PhantomData,
@@ -257,7 +257,7 @@ macro_rules! dac_helper {
                 /// Disable the DAC channel
                 pub fn disable(self) -> $CX<MODE_BITS, Disabled> {
                     let dac = unsafe { &(*<$DAC>::ptr()) };
-                    dac.dac_cr.modify(|_, w| unsafe {
+                    dac.cr().modify(|_, w| unsafe {
                         w.$en().clear_bit().$wave().bits(0).$ten().clear_bit()
                     });
 
@@ -272,12 +272,12 @@ macro_rules! dac_helper {
             impl<const MODE_BITS: u8, ED> DacOut<u16> for $CX<MODE_BITS, ED> {
                 fn set_value(&mut self, val: u16) {
                     let dac = unsafe { &(*<$DAC>::ptr()) };
-                    dac.$dhrx.write(|w| unsafe { w.bits(val as u32) });
+                    dac.$dhrx().write(|w| unsafe { w.bits(val as u32) });
                 }
 
                 fn get_value(&mut self) -> u16 {
                     let dac = unsafe { &(*<$DAC>::ptr()) };
-                    dac.$dac_dor.read().bits() as u16
+                    dac.$dor().read().bits() as u16
                 }
             }
 
@@ -285,7 +285,7 @@ macro_rules! dac_helper {
             impl<const MODE_BITS: u8> $CX<MODE_BITS, WaveGenerator> {
                 pub fn trigger(&mut self) {
                     let dac = unsafe { &(*<$DAC>::ptr()) };
-                    dac.dac_swtrgr.write(|w| { w.$swtrig().set_bit() });
+                    dac.swtrgr().write(|w| { w.$swtrig().set_bit() });
                 }
             }
         )+
@@ -300,8 +300,8 @@ macro_rules! dac {
             cal_flag1,
             otrim1,
             mode1,
-            dac_dhr12r1,
-            dac_dor1,
+            dhr12r1,
+            dor1,
             dacc1dhr,
             wave1,
             mamp1,
@@ -314,8 +314,8 @@ macro_rules! dac {
             cal_flag2,
             otrim2,
             mode2,
-            dac_dhr12r2,
-            dac_dor2,
+            dhr12r2,
+            dor2,
             dacc2dhr,
             wave2,
             mamp2,

--- a/src/dma/stream.rs
+++ b/src/dma/stream.rs
@@ -508,28 +508,15 @@ macro_rules! dma_stream {
     };
 }
 
-
 dma_stream!(
     // Note: the field names start from one, unlike the RM where they start from
     // zero. May need updating if it gets fixed upstream.
-    (
-        Stream0, 0, 1
-    ),
-    (
-        Stream1, 1, 2
-    ),
-    (
-        Stream2, 2, 3
-    ),
-    (
-        Stream3, 3, 4
-    ),
-    (
-        Stream4, 4, 5
-    ),
-    (
-        Stream5, 5, 6
-    ),
+    (Stream0, 0, 1),
+    (Stream1, 1, 2),
+    (Stream2, 2, 3),
+    (Stream3, 3, 4),
+    (Stream4, 4, 5),
+    (Stream5, 5, 6),
 );
 
 // Cat 3 and 4 devices
@@ -545,10 +532,6 @@ dma_stream!(
 dma_stream!(
     // Note: the field names start from one, unlike the RM where they start from
     // zero. May need updating if it gets fixed upstream.
-    (
-        Stream6, 6, 7
-    ),
-    (
-        Stream7, 7, 8
-    ),
+    (Stream6, 6, 7),
+    (Stream7, 7, 8),
 );

--- a/src/dma/stream.rs
+++ b/src/dma/stream.rs
@@ -131,13 +131,13 @@ pub trait DMAExt<I> {
 impl DMAExt<Self> for DMA1 {
     fn split(self, rcc: &Rcc) -> StreamsTuple<DMA1> {
         // Enable DMAMux is not yet enabled
-        if !rcc.rb.ahb1enr.read().dmamuxen().bit_is_set() {
+        if !rcc.rb.ahb1enr().read().dmamuxen().bit_is_set() {
             // Enable peripheral
-            rcc.rb.ahb1enr.modify(|_, w| w.dmamuxen().set_bit());
+            rcc.rb.ahb1enr().modify(|_, w| w.dmamuxen().set_bit());
         }
 
         // Enable peripheral
-        rcc.rb.ahb1enr.modify(|_, w| w.dma1en().set_bit());
+        rcc.rb.ahb1enr().modify(|_, w| w.dma1en().set_bit());
 
         StreamsTuple::new(self)
     }
@@ -146,13 +146,13 @@ impl DMAExt<Self> for DMA1 {
 impl DMAExt<Self> for DMA2 {
     fn split(self, rcc: &Rcc) -> StreamsTuple<DMA2> {
         // Enable DMAMux is not yet enabled
-        if !rcc.rb.ahb1enr.read().dmamuxen().bit_is_set() {
+        if !rcc.rb.ahb1enr().read().dmamuxen().bit_is_set() {
             // Enable peripheral
-            rcc.rb.ahb1enr.modify(|_, w| w.dmamuxen().set_bit());
+            rcc.rb.ahb1enr().modify(|_, w| w.dmamuxen().set_bit());
         }
 
         // Enable peripheral
-        rcc.rb.ahb1enr.modify(|_, w| w.dma2en().set_bit());
+        rcc.rb.ahb1enr().modify(|_, w| w.dma2en().set_bit());
 
         StreamsTuple::new(self)
     }
@@ -181,339 +181,356 @@ impl<I: Instance> StreamsTuple<I> {
 // The implementation does the heavy lifting of mapping to the right fields on
 // the stream
 macro_rules! dma_stream {
-    ($(($name:ident, $number:expr,
-        regs => $chX:ident,
-        fields => $tcif:ident, $htif:ident, $teif:ident, $gif:ident, $tcisr:ident, $htisr:ident, $teisr:ident, $gisr:ident,
-        dmamux => $dma1_cXcr:ident, $dma2_cXcr:ident, )
-    ),+$(,)*) => {
-        $(
-            impl<I: Instance> Stream for $name<I> {
+    ($(($name:ident, $number:expr, $x:literal)),+$(,)*) => {
+        paste::paste!{
+            $(
+                impl<I: Instance> Stream for $name<I> {
 
-                const NUMBER: usize = $number;
-                type Config = DmaConfig;
-                type Interrupts = DmaInterrupts;
+                    const NUMBER: usize = $number;
+                    type Config = DmaConfig;
+                    type Interrupts = DmaInterrupts;
 
-                fn apply_config(&mut self, config: DmaConfig) {
-                    self.set_priority(config.priority);
-                    self.set_memory_increment(config.memory_increment);
-                    self.set_peripheral_increment(config.peripheral_increment);
-                    self.set_circular_buffer(config.circular_buffer);
-                    self.set_transfer_complete_interrupt_enable(
-                        config.transfer_complete_interrupt
-                    );
-                    self.set_half_transfer_interrupt_enable(config.half_transfer_interrupt);
-                    self.set_transfer_error_interrupt_enable(
-                        config.transfer_error_interrupt
-                    );
-               }
+                    fn apply_config(&mut self, config: DmaConfig) {
+                        self.set_priority(config.priority);
+                        self.set_memory_increment(config.memory_increment);
+                        self.set_peripheral_increment(config.peripheral_increment);
+                        self.set_circular_buffer(config.circular_buffer);
+                        self.set_transfer_complete_interrupt_enable(
+                            config.transfer_complete_interrupt
+                        );
+                        self.set_half_transfer_interrupt_enable(config.half_transfer_interrupt);
+                        self.set_transfer_error_interrupt_enable(
+                            config.transfer_error_interrupt
+                        );
+                    }
 
-                #[inline(always)]
-                fn clear_interrupts(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr.write(|w| w
-                                    .$tcif().set_bit() //Clear transfer complete interrupt flag
-                                    .$htif().set_bit() //Clear half transfer interrupt flag
-                                    .$teif().set_bit() //Clear transfer error interrupt flag
-                                    .$gif().set_bit() //Clear global interrupt flag
-                    );
-                    let _ = dma.isr.read();
-                    let _ = dma.isr.read(); // Delay 2 peripheral clocks
-                }
+                    #[inline(always)]
+                    fn clear_interrupts(&mut self) {
+                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                        // that belongs to the StreamX
+                        let dma = unsafe { &*I::ptr() };
+                        dma.ifcr().write(|w| w
+                                        .[<ctcif $x>]().set_bit() //Clear transfer complete interrupt flag
+                                        .[<chtif $x>]().set_bit() //Clear half transfer interrupt flag
+                                        .[<cteif $x>]().set_bit() //Clear transfer error interrupt flag
+                                        .[<cgif $x>]().set_bit() //Clear global interrupt flag
+                        );
+                        let _ = dma.isr().read();
+                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                    }
 
-                #[inline(always)]
-                fn clear_transfer_complete_flag(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr.write(|w| w.$tcif().set_bit());
-                }
+                    #[inline(always)]
+                    fn clear_transfer_complete_flag(&mut self) {
+                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                        // that belongs to the StreamX
+                        let dma = unsafe { &*I::ptr() };
+                        dma.ifcr().write(|w| w.[<ctcif $x>]().set_bit());
+                    }
 
-                #[inline(always)]
-                fn clear_transfer_complete_interrupt(&mut self) {
-                    self.clear_transfer_complete_flag();
-                    //NOTE(unsafe) Atomic read with no side-effects.
-                    let dma = unsafe { &*I::ptr() };
-                    let _ = dma.isr.read();
-                    let _ = dma.isr.read(); // Delay 2 peripheral clocks
-                }
+                    #[inline(always)]
+                    fn clear_transfer_complete_interrupt(&mut self) {
+                        self.clear_transfer_complete_flag();
+                        //NOTE(unsafe) Atomic read with no side-effects.
+                        let dma = unsafe { &*I::ptr() };
+                        let _ = dma.isr().read();
+                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                    }
 
-                #[inline(always)]
-                fn clear_transfer_error_interrupt(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr.write(|w| w.$teif().set_bit());
-                    let _ = dma.isr.read();
-                    let _ = dma.isr.read(); // Delay 2 peripheral clocks
-                }
+                    #[inline(always)]
+                    fn clear_transfer_error_interrupt(&mut self) {
+                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                        // that belongs to the StreamX
+                        let dma = unsafe { &*I::ptr() };
+                        dma.ifcr().write(|w| w.[<ctcif $x>]().set_bit());
+                        let _ = dma.isr().read();
+                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                    }
 
-                #[inline(always)]
-                fn get_transfer_complete_flag() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma = unsafe { &*I::ptr() };
-                    dma.isr.read().$tcisr().bit_is_set()
-                }
+                    #[inline(always)]
+                    fn get_transfer_complete_flag() -> bool {
+                        //NOTE(unsafe) Atomic read with no side effects
+                        let dma = unsafe { &*I::ptr() };
+                        dma.isr().read().[<tcif $x>]().bit_is_set()
+                    }
 
-                #[inline(always)]
-                fn get_transfer_error_flag() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma = unsafe { &*I::ptr() };
-                    dma.isr.read().$teisr().bit_is_set()
-                }
+                    #[inline(always)]
+                    fn get_transfer_error_flag() -> bool {
+                        //NOTE(unsafe) Atomic read with no side effects
+                        let dma = unsafe { &*I::ptr() };
+                        dma.isr().read().[<tcif $x>]().bit_is_set()
+                    }
 
-                #[inline(always)]
-                unsafe fn enable(&mut self) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = &unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| w.en().set_bit());
-                }
-
-                #[inline(always)]
-                fn is_enabled() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma_ch = &unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.read().en().bit_is_set()
-                }
-
-                fn disable(&mut self) {
-                    if Self::is_enabled() {
+                    #[inline(always)]
+                    unsafe fn enable(&mut self) {
                         //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = &unsafe { &*I::ptr() }.$chX();
-
-                        // Aborting an on-going transfer might cause interrupts to fire, disable
-                        // them
-                        let interrupts = Self::get_interrupts_enable();
-                        self.disable_interrupts();
-
-                        dma_ch.cr.modify(|_, w| w.en().clear_bit());
-                        while Self::is_enabled() {}
-
-                        self.clear_interrupts();
-                        self.enable_interrupts(interrupts);
+                        let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| w.en().set_bit());
                     }
-                }
 
-                #[inline(always)]
-                fn set_request_line(&mut self, request_line: u8) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dmamux = unsafe { &*I::mux_ptr() };
-                    unsafe {
-                        if I::IS_DMA1 {
-                            dmamux.$dma1_cXcr
-                                .modify(|_, w| w.dmareq_id().bits(request_line));
-                        } else {
-                            dmamux.$dma2_cXcr
-                                .modify(|_, w| w.dmareq_id().bits(request_line));
-                        };
+                    #[inline(always)]
+                    fn is_enabled() -> bool {
+                        //NOTE(unsafe) Atomic read with no side effects
+                        let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().read().en().bit_is_set()
                     }
-                }
 
-                #[inline(always)]
-                fn set_priority(&mut self, priority: config::Priority) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = &unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| unsafe { w.pl().bits(priority.bits()) });
-                }
+                    fn disable(&mut self) {
+                        if Self::is_enabled() {
+                            //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                            let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
 
-                #[inline(always)]
-                fn disable_interrupts(&mut self) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dmacr = &unsafe { &*I::ptr() }.$chX().cr;
-                    dmacr.modify(|_, w| w
-                        .tcie().clear_bit()
-                        .teie().clear_bit()
-                        .htie().clear_bit());
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
+                            // Aborting an on-going transfer might cause interrupts to fire, disable
+                            // them
+                            let interrupts = Self::get_interrupts_enable();
+                            self.disable_interrupts();
 
-                #[inline(always)]
-                fn enable_interrupts(&mut self, interrupt: Self::Interrupts) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = &unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| w
-                                                   .tcie().bit(interrupt.transfer_complete)
-                                                   .teie().bit(interrupt.transfer_error)
-                                                   .htie().bit(interrupt.half_transfer)
-                    );
-                }
+                            dma_ch.cr().modify(|_, w| w.en().clear_bit());
+                            while Self::is_enabled() {}
 
-                #[inline(always)]
-                fn get_interrupts_enable() -> Self::Interrupts {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    let cr = dma_ch.cr.read();
-
-                    DmaInterrupts {
-                        transfer_complete: cr.tcie().bit_is_set(),
-                        half_transfer: cr.htie().bit_is_set(),
-                        transfer_error: cr.teie().bit_is_set()
-                    }
-                }
-
-
-                #[inline(always)]
-                fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dmacr = &unsafe { &*I::ptr() }.$chX().cr;
-                    dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn set_transfer_error_interrupt_enable(&mut self, transfer_error_interrupt: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dmacr = &unsafe { &*I::ptr() }.$chX().cr;
-                    dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dmacr = &unsafe { &*I::ptr() }.$chX().cr;
-                    dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn get_half_transfer_flag() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma = unsafe { &*I::ptr() };
-                    dma.isr.read().$htisr().bit_is_set()
-                }
-
-                #[inline(always)]
-                fn clear_half_transfer_interrupt(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr.write(|w| w.$htif().set_bit());
-                    let _ = dma.isr.read();
-                    let _ = dma.isr.read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                unsafe fn set_peripheral_address(&mut self, value: u32) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.par.write(|w| w.pa().bits(value));
-                }
-
-                #[inline(always)]
-                unsafe fn set_memory_address(&mut self, value: u32) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.mar.write(|w| w.ma().bits(value) );
-                }
-
-                #[inline(always)]
-                fn get_memory_address(&self) -> u32 {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.mar.read().ma().bits()
-                }
-
-                #[inline(always)]
-                fn set_number_of_transfers(&mut self, value: u16) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.ndtr.write(|w| unsafe {w.ndt().bits(value) });
-                }
-
-                #[inline(always)]
-                fn get_number_of_transfers() -> u16 {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.ndtr.read().ndt().bits()
-                }
-                #[inline(always)]
-                unsafe fn set_memory_size(&mut self, size: u8) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| w.msize().bits(size));
-                }
-
-                #[inline(always)]
-                unsafe fn set_peripheral_size(&mut self, size: u8) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| w.psize().bits(size));
-                }
-
-                #[inline(always)]
-                fn set_memory_increment(&mut self, increment: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| w.minc().bit(increment));
-                }
-
-                #[inline(always)]
-                fn set_peripheral_increment(&mut self, increment: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| w.pinc().bit(increment));
-                }
-
-                #[inline(always)]
-                fn set_direction(&mut self, direction: DmaDirection) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| {
-                        match direction {
-                            DmaDirection::PeripheralToMemory =>
-                                w.dir().clear_bit().mem2mem().clear_bit(),
-                            DmaDirection::MemoryToPeripheral =>
-                                w.dir().set_bit().mem2mem().clear_bit(),
-                            DmaDirection::MemoryToMemory =>
-                                w.mem2mem().set_bit().dir().clear_bit(),
+                            self.clear_interrupts();
+                            self.enable_interrupts(interrupts);
                         }
-                    });
+                    }
+
+                    #[inline(always)]
+                    fn set_request_line(&mut self, request_line: u8) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dmamux = unsafe { &*I::mux_ptr() };
+                        unsafe {
+                            dmamux.ccr($number)
+                                .modify(|_, w| w.dmareq_id().bits(request_line));
+                        }
+                    }
+
+                    #[inline(always)]
+                    fn set_priority(&mut self, priority: config::Priority) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| unsafe { w.pl().bits(priority.bits()) });
+                    }
+
+                    #[inline(always)]
+                    fn disable_interrupts(&mut self) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
+                        dmacr.modify(|_, w| w
+                            .tcie().clear_bit()
+                            .teie().clear_bit()
+                            .htie().clear_bit());
+                        let _ = dmacr.read();
+                        let _ = dmacr.read(); // Delay 2 peripheral clocks
+                    }
+
+                    #[inline(always)]
+                    fn enable_interrupts(&mut self, interrupt: Self::Interrupts) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| w
+                                                    .tcie().bit(interrupt.transfer_complete)
+                                                    .teie().bit(interrupt.transfer_error)
+                                                    .htie().bit(interrupt.half_transfer)
+                        );
+                    }
+
+                    #[inline(always)]
+                    fn get_interrupts_enable() -> Self::Interrupts {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        let cr = dma_ch.cr().read();
+
+                        DmaInterrupts {
+                            transfer_complete: cr.tcie().bit_is_set(),
+                            half_transfer: cr.htie().bit_is_set(),
+                            transfer_error: cr.teie().bit_is_set()
+                        }
+                    }
+
+
+                    #[inline(always)]
+                    fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
+                        dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
+                        let _ = dmacr.read();
+                        let _ = dmacr.read(); // Delay 2 peripheral clocks
+                    }
+
+                    #[inline(always)]
+                    fn set_transfer_error_interrupt_enable(&mut self, transfer_error_interrupt: bool) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
+                        dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
+                        let _ = dmacr.read();
+                        let _ = dmacr.read(); // Delay 2 peripheral clocks
+                    }
+
+                    #[inline(always)]
+                    fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
+                        dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+                        let _ = dmacr.read();
+                        let _ = dmacr.read(); // Delay 2 peripheral clocks
+                    }
+
+                    #[inline(always)]
+                    fn get_half_transfer_flag() -> bool {
+                        //NOTE(unsafe) Atomic read with no side effects
+                        let dma = unsafe { &*I::ptr() };
+                        dma.isr().read().[<htif $x>]().bit_is_set()
+                    }
+
+                    #[inline(always)]
+                    fn clear_half_transfer_interrupt(&mut self) {
+                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                        // that belongs to the StreamX
+                        let dma = unsafe { &*I::ptr() };
+                        dma.ifcr().write(|w| w.[<chtif $x>]().set_bit());
+                        let _ = dma.isr().read();
+                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                    }
+
+                    #[inline(always)]
+                    unsafe fn set_peripheral_address(&mut self, value: u32) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.par().write(|w| w.pa().bits(value));
+                    }
+
+                    #[inline(always)]
+                    unsafe fn set_memory_address(&mut self, value: u32) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.mar().write(|w| w.ma().bits(value) );
+                    }
+
+                    #[inline(always)]
+                    fn get_memory_address(&self) -> u32 {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.mar().read().ma().bits()
+                    }
+
+                    #[inline(always)]
+                    fn set_number_of_transfers(&mut self, value: u16) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.ndtr().write(|w| unsafe {w.ndt().bits(value) });
+                    }
+
+                    #[inline(always)]
+                    fn get_number_of_transfers() -> u16 {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.ndtr().read().ndt().bits()
+                    }
+                    #[inline(always)]
+                    unsafe fn set_memory_size(&mut self, size: u8) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| w.msize().bits(size));
+                    }
+
+                    #[inline(always)]
+                    unsafe fn set_peripheral_size(&mut self, size: u8) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| w.psize().bits(size));
+                    }
+
+                    #[inline(always)]
+                    fn set_memory_increment(&mut self, increment: bool) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| w.minc().bit(increment));
+                    }
+
+                    #[inline(always)]
+                    fn set_peripheral_increment(&mut self, increment: bool) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| w.pinc().bit(increment));
+                    }
+
+                    #[inline(always)]
+                    fn set_direction(&mut self, direction: DmaDirection) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| {
+                            match direction {
+                                DmaDirection::PeripheralToMemory =>
+                                    w.dir().clear_bit().mem2mem().clear_bit(),
+                                DmaDirection::MemoryToPeripheral =>
+                                    w.dir().set_bit().mem2mem().clear_bit(),
+                                DmaDirection::MemoryToMemory =>
+                                    w.mem2mem().set_bit().dir().clear_bit(),
+                            }
+                        });
+                    }
+
+                    #[inline(always)]
+                    fn set_circular_buffer(&mut self, circular_buffer: bool) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| w.circ().bit(circular_buffer));
+                    }
                 }
 
-                #[inline(always)]
-                fn set_circular_buffer(&mut self, circular_buffer: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dma_ch = unsafe { &*I::ptr() }.$chX();
-                    dma_ch.cr.modify(|_, w| w.circ().bit(circular_buffer));
-                }
-            }
+                impl<I: Instance> $name<I> {
+                    #[inline(always)]
+                    pub fn clear_half_transfer_interrupt(&mut self) {
+                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                        // that belongs to the StreamX
+                        let dma = unsafe { &*I::ptr() };
+                        dma.ifcr().write(|w| w.[<chtif $x>]().set_bit());
+                        let _ = dma.isr().read();
+                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                    }
 
-            impl<I: Instance> $name<I> {
-                #[inline(always)]
-                pub fn clear_half_transfer_interrupt(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the StreamX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr.write(|w| w.$htif().set_bit());
-                    let _ = dma.isr.read();
-                    let _ = dma.isr.read(); // Delay 2 peripheral clocks
-                }
+                    #[inline(always)]
+                    pub fn get_half_transfer_flag() -> bool {
+                        //NOTE(unsafe) Atomic read with no side effects
+                        let dma = unsafe { &*I::ptr() };
+                        dma.isr().read().[<htif $x>]().bit_is_set()
+                    }
 
-                #[inline(always)]
-                pub fn get_half_transfer_flag() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma = unsafe { &*I::ptr() };
-                    dma.isr.read().$htisr().bit_is_set()
+                    #[inline(always)]
+                    pub fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
+                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
+                        dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+                        let _ = dmacr.read();
+                        let _ = dmacr.read(); // Delay 2 peripheral clocks
+                    }
                 }
-
-                #[inline(always)]
-                pub fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                    let dmacr = &unsafe { &*I::ptr() }.$chX().cr;
-                    dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-            }
-        )+
+            )+
+        }
     };
 }
+
+
+dma_stream!(
+    // Note: the field names start from one, unlike the RM where they start from
+    // zero. May need updating if it gets fixed upstream.
+    (
+        Stream0, 0, 1
+    ),
+    (
+        Stream1, 1, 2
+    ),
+    (
+        Stream2, 2, 3
+    ),
+    (
+        Stream3, 3, 4
+    ),
+    (
+        Stream4, 4, 5
+    ),
+    (
+        Stream5, 5, 6
+    ),
+);
 
 // Cat 3 and 4 devices
 #[cfg(any(
@@ -529,94 +546,9 @@ dma_stream!(
     // Note: the field names start from one, unlike the RM where they start from
     // zero. May need updating if it gets fixed upstream.
     (
-        Stream0, 0,
-        regs => ch1,
-        fields => tcif1, htif1, teif1, gif1, tcif1, htif1, teif1, gif1,
-        dmamux => c0cr, c8cr,
+        Stream6, 6, 7
     ),
     (
-        Stream1, 1,
-        regs => ch2,
-        fields => tcif2, htif2, teif2, gif2, tcif2, htif2, teif2, gif2,
-        dmamux => c1cr, c9cr,
-    ),
-    (
-        Stream2, 2,
-        regs => ch3,
-        fields => tcif3, htif3, teif3, gif3, tcif3, htif3, teif3, gif3,
-        dmamux => c2cr, c10cr,
-    ),
-    (
-        Stream3, 3,
-        regs => ch4,
-        fields => tcif4, htif4, teif4, gif4, tcif4, htif4, teif4, gif4,
-        dmamux => c3cr, c11cr,
-    ),
-    (
-        Stream4, 4,
-        regs => ch5,
-        fields => tcif5, htif5, teif5, gif5, tcif5, htif5, teif5, gif5,
-        dmamux => c4cr, c12cr,
-    ),
-    (
-        Stream5, 5,
-        regs => ch6,
-        fields => tcif6, htif6, teif6, gif6, tcif6, htif6, teif6, gif6,
-        dmamux => c5cr, c13cr,
-    ),
-    (
-        Stream6, 6,
-        regs => ch7,
-        fields => tcif7, htif7, teif7, gif7, tcif7, htif7, teif7, gif7,
-        dmamux => c6cr, c14cr,
-    ),
-    (
-        Stream7, 7,
-        regs => ch8,
-        fields => tcif8, htif8, teif8, gif8, tcif8, htif8, teif8, gif8,
-        dmamux => c7cr, c15cr,
-    ),
-);
-
-// Cat 2 devices
-#[cfg(any(feature = "stm32g431", feature = "stm32g441",))]
-dma_stream!(
-    // Note: the field names start from one, unlike the RM where they start from
-    // zero. May need updating if it gets fixed upstream.
-    (
-        Stream0, 0,
-        regs => ccr1, cpar1, cmar1, cndtr1,
-        fields => tcif1, htif1, teif1, gif1, tcif1, htif1, teif1, gif1,
-        dmamux => c0cr, c6cr,
-    ),
-    (
-        Stream1, 1,
-        regs => ccr2, cpar2, cmar2, cndtr2,
-        fields => tcif2, htif2, teif2, gif2, tcif2, htif2, teif2, gif2,
-        dmamux => c1cr, c7cr,
-    ),
-    (
-        Stream2, 2,
-        regs => ccr3, cpar3, cmar3, cndtr3,
-        fields => tcif3, htif3, teif3, gif3, tcif3, htif3, teif3, gif3,
-        dmamux => c2cr, c8cr,
-    ),
-    (
-        Stream3, 3,
-        regs => ccr4, cpar4, cmar4, cndtr4,
-        fields => tcif4, htif4, teif4, gif4, tcif4, htif4, teif4, gif4,
-        dmamux => c3cr, c9cr,
-    ),
-    (
-        Stream4, 4,
-        regs => ccr5, cpar5, cmar5, cndtr5,
-        fields => tcif5, htif5, teif5, gif5, tcif5, htif5, teif5, gif5,
-        dmamux => c4cr, c10cr,
-    ),
-    (
-        Stream5, 5,
-        regs => ccr6, cpar6, cmar6, cndtr6,
-        fields => tcif6, htif6, teif6, gif6, tcif6, htif6, teif6, gif6,
-        dmamux => c5cr, c11cr,
+        Stream7, 7, 8
     ),
 );

--- a/src/dma/stream.rs
+++ b/src/dma/stream.rs
@@ -182,329 +182,329 @@ impl<I: Instance> StreamsTuple<I> {
 // the stream
 macro_rules! dma_stream {
     ($(($name:ident, $number:expr, $x:literal)),+$(,)*) => {
-        paste::paste!{
-            $(
-                impl<I: Instance> Stream for $name<I> {
+        $(
+            impl<I: Instance> Stream for $name<I> {
 
-                    const NUMBER: usize = $number;
-                    type Config = DmaConfig;
-                    type Interrupts = DmaInterrupts;
+                const NUMBER: usize = $number;
+                type Config = DmaConfig;
+                type Interrupts = DmaInterrupts;
 
-                    fn apply_config(&mut self, config: DmaConfig) {
-                        self.set_priority(config.priority);
-                        self.set_memory_increment(config.memory_increment);
-                        self.set_peripheral_increment(config.peripheral_increment);
-                        self.set_circular_buffer(config.circular_buffer);
-                        self.set_transfer_complete_interrupt_enable(
-                            config.transfer_complete_interrupt
-                        );
-                        self.set_half_transfer_interrupt_enable(config.half_transfer_interrupt);
-                        self.set_transfer_error_interrupt_enable(
-                            config.transfer_error_interrupt
-                        );
-                    }
+                fn apply_config(&mut self, config: DmaConfig) {
+                    self.set_priority(config.priority);
+                    self.set_memory_increment(config.memory_increment);
+                    self.set_peripheral_increment(config.peripheral_increment);
+                    self.set_circular_buffer(config.circular_buffer);
+                    self.set_transfer_complete_interrupt_enable(
+                        config.transfer_complete_interrupt
+                    );
+                    self.set_half_transfer_interrupt_enable(config.half_transfer_interrupt);
+                    self.set_transfer_error_interrupt_enable(
+                        config.transfer_error_interrupt
+                    );
+                }
 
-                    #[inline(always)]
-                    fn clear_interrupts(&mut self) {
-                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                        // that belongs to the StreamX
-                        let dma = unsafe { &*I::ptr() };
-                        dma.ifcr().write(|w| w
-                                        .[<ctcif $x>]().set_bit() //Clear transfer complete interrupt flag
-                                        .[<chtif $x>]().set_bit() //Clear half transfer interrupt flag
-                                        .[<cteif $x>]().set_bit() //Clear transfer error interrupt flag
-                                        .[<cgif $x>]().set_bit() //Clear global interrupt flag
-                        );
-                        let _ = dma.isr().read();
-                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                    }
+                #[inline(always)]
+                fn clear_interrupts(&mut self) {
+                    let num = Self::NUMBER as u8;
 
-                    #[inline(always)]
-                    fn clear_transfer_complete_flag(&mut self) {
-                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                        // that belongs to the StreamX
-                        let dma = unsafe { &*I::ptr() };
-                        dma.ifcr().write(|w| w.[<ctcif $x>]().set_bit());
-                    }
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let dma = unsafe { &*I::ptr() };
+                    dma.ifcr().write(|w| w
+                        .ctcif(num).set_bit() //Clear transfer complete interrupt flag
+                        .chtif(num).set_bit() //Clear half transfer interrupt flag
+                        .cteif(num).set_bit() //Clear transfer error interrupt flag
+                        .cgif(num).set_bit() //Clear global interrupt flag
+                    );
+                    let _ = dma.isr().read();
+                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                }
 
-                    #[inline(always)]
-                    fn clear_transfer_complete_interrupt(&mut self) {
-                        self.clear_transfer_complete_flag();
-                        //NOTE(unsafe) Atomic read with no side-effects.
-                        let dma = unsafe { &*I::ptr() };
-                        let _ = dma.isr().read();
-                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                    }
+                #[inline(always)]
+                fn clear_transfer_complete_flag(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let dma = unsafe { &*I::ptr() };
+                    dma.ifcr().write(|w| w.ctcif(Self::NUMBER as u8).set_bit());
+                }
 
-                    #[inline(always)]
-                    fn clear_transfer_error_interrupt(&mut self) {
-                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                        // that belongs to the StreamX
-                        let dma = unsafe { &*I::ptr() };
-                        dma.ifcr().write(|w| w.[<ctcif $x>]().set_bit());
-                        let _ = dma.isr().read();
-                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                    }
+                #[inline(always)]
+                fn clear_transfer_complete_interrupt(&mut self) {
+                    self.clear_transfer_complete_flag();
+                    //NOTE(unsafe) Atomic read with no side-effects.
+                    let dma = unsafe { &*I::ptr() };
+                    let _ = dma.isr().read();
+                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                }
 
-                    #[inline(always)]
-                    fn get_transfer_complete_flag() -> bool {
-                        //NOTE(unsafe) Atomic read with no side effects
-                        let dma = unsafe { &*I::ptr() };
-                        dma.isr().read().[<tcif $x>]().bit_is_set()
-                    }
+                #[inline(always)]
+                fn clear_transfer_error_interrupt(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let dma = unsafe { &*I::ptr() };
+                    dma.ifcr().write(|w| w.ctcif(Self::NUMBER as u8).set_bit());
+                    let _ = dma.isr().read();
+                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                }
 
-                    #[inline(always)]
-                    fn get_transfer_error_flag() -> bool {
-                        //NOTE(unsafe) Atomic read with no side effects
-                        let dma = unsafe { &*I::ptr() };
-                        dma.isr().read().[<tcif $x>]().bit_is_set()
-                    }
+                #[inline(always)]
+                fn get_transfer_complete_flag() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let dma = unsafe { &*I::ptr() };
+                    dma.isr().read().tcif(Self::NUMBER as u8).bit_is_set()
+                }
 
-                    #[inline(always)]
-                    unsafe fn enable(&mut self) {
+                #[inline(always)]
+                fn get_transfer_error_flag() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let dma = unsafe { &*I::ptr() };
+                    dma.isr().read().tcif(Self::NUMBER as u8).bit_is_set()
+                }
+
+                #[inline(always)]
+                unsafe fn enable(&mut self) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| w.en().set_bit());
+                }
+
+                #[inline(always)]
+                fn is_enabled() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().read().en().bit_is_set()
+                }
+
+                fn disable(&mut self) {
+                    if Self::is_enabled() {
                         //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| w.en().set_bit());
-                    }
+                        let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
 
-                    #[inline(always)]
-                    fn is_enabled() -> bool {
-                        //NOTE(unsafe) Atomic read with no side effects
-                        let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().read().en().bit_is_set()
-                    }
+                        // Aborting an on-going transfer might cause interrupts to fire, disable
+                        // them
+                        let interrupts = Self::get_interrupts_enable();
+                        self.disable_interrupts();
 
-                    fn disable(&mut self) {
-                        if Self::is_enabled() {
-                            //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                            let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
+                        dma_ch.cr().modify(|_, w| w.en().clear_bit());
+                        while Self::is_enabled() {}
 
-                            // Aborting an on-going transfer might cause interrupts to fire, disable
-                            // them
-                            let interrupts = Self::get_interrupts_enable();
-                            self.disable_interrupts();
-
-                            dma_ch.cr().modify(|_, w| w.en().clear_bit());
-                            while Self::is_enabled() {}
-
-                            self.clear_interrupts();
-                            self.enable_interrupts(interrupts);
-                        }
-                    }
-
-                    #[inline(always)]
-                    fn set_request_line(&mut self, request_line: u8) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dmamux = unsafe { &*I::mux_ptr() };
-                        unsafe {
-                            dmamux.ccr($number)
-                                .modify(|_, w| w.dmareq_id().bits(request_line));
-                        }
-                    }
-
-                    #[inline(always)]
-                    fn set_priority(&mut self, priority: config::Priority) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| unsafe { w.pl().bits(priority.bits()) });
-                    }
-
-                    #[inline(always)]
-                    fn disable_interrupts(&mut self) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
-                        dmacr.modify(|_, w| w
-                            .tcie().clear_bit()
-                            .teie().clear_bit()
-                            .htie().clear_bit());
-                        let _ = dmacr.read();
-                        let _ = dmacr.read(); // Delay 2 peripheral clocks
-                    }
-
-                    #[inline(always)]
-                    fn enable_interrupts(&mut self, interrupt: Self::Interrupts) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = &unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| w
-                                                    .tcie().bit(interrupt.transfer_complete)
-                                                    .teie().bit(interrupt.transfer_error)
-                                                    .htie().bit(interrupt.half_transfer)
-                        );
-                    }
-
-                    #[inline(always)]
-                    fn get_interrupts_enable() -> Self::Interrupts {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        let cr = dma_ch.cr().read();
-
-                        DmaInterrupts {
-                            transfer_complete: cr.tcie().bit_is_set(),
-                            half_transfer: cr.htie().bit_is_set(),
-                            transfer_error: cr.teie().bit_is_set()
-                        }
-                    }
-
-
-                    #[inline(always)]
-                    fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
-                        dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
-                        let _ = dmacr.read();
-                        let _ = dmacr.read(); // Delay 2 peripheral clocks
-                    }
-
-                    #[inline(always)]
-                    fn set_transfer_error_interrupt_enable(&mut self, transfer_error_interrupt: bool) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
-                        dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
-                        let _ = dmacr.read();
-                        let _ = dmacr.read(); // Delay 2 peripheral clocks
-                    }
-
-                    #[inline(always)]
-                    fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
-                        dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                        let _ = dmacr.read();
-                        let _ = dmacr.read(); // Delay 2 peripheral clocks
-                    }
-
-                    #[inline(always)]
-                    fn get_half_transfer_flag() -> bool {
-                        //NOTE(unsafe) Atomic read with no side effects
-                        let dma = unsafe { &*I::ptr() };
-                        dma.isr().read().[<htif $x>]().bit_is_set()
-                    }
-
-                    #[inline(always)]
-                    fn clear_half_transfer_interrupt(&mut self) {
-                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                        // that belongs to the StreamX
-                        let dma = unsafe { &*I::ptr() };
-                        dma.ifcr().write(|w| w.[<chtif $x>]().set_bit());
-                        let _ = dma.isr().read();
-                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                    }
-
-                    #[inline(always)]
-                    unsafe fn set_peripheral_address(&mut self, value: u32) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.par().write(|w| w.pa().bits(value));
-                    }
-
-                    #[inline(always)]
-                    unsafe fn set_memory_address(&mut self, value: u32) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.mar().write(|w| w.ma().bits(value) );
-                    }
-
-                    #[inline(always)]
-                    fn get_memory_address(&self) -> u32 {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.mar().read().ma().bits()
-                    }
-
-                    #[inline(always)]
-                    fn set_number_of_transfers(&mut self, value: u16) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.ndtr().write(|w| unsafe {w.ndt().bits(value) });
-                    }
-
-                    #[inline(always)]
-                    fn get_number_of_transfers() -> u16 {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.ndtr().read().ndt().bits()
-                    }
-                    #[inline(always)]
-                    unsafe fn set_memory_size(&mut self, size: u8) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| w.msize().bits(size));
-                    }
-
-                    #[inline(always)]
-                    unsafe fn set_peripheral_size(&mut self, size: u8) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| w.psize().bits(size));
-                    }
-
-                    #[inline(always)]
-                    fn set_memory_increment(&mut self, increment: bool) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| w.minc().bit(increment));
-                    }
-
-                    #[inline(always)]
-                    fn set_peripheral_increment(&mut self, increment: bool) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| w.pinc().bit(increment));
-                    }
-
-                    #[inline(always)]
-                    fn set_direction(&mut self, direction: DmaDirection) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| {
-                            match direction {
-                                DmaDirection::PeripheralToMemory =>
-                                    w.dir().clear_bit().mem2mem().clear_bit(),
-                                DmaDirection::MemoryToPeripheral =>
-                                    w.dir().set_bit().mem2mem().clear_bit(),
-                                DmaDirection::MemoryToMemory =>
-                                    w.mem2mem().set_bit().dir().clear_bit(),
-                            }
-                        });
-                    }
-
-                    #[inline(always)]
-                    fn set_circular_buffer(&mut self, circular_buffer: bool) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dma_ch = unsafe { &*I::ptr() }.[<ch $x>]();
-                        dma_ch.cr().modify(|_, w| w.circ().bit(circular_buffer));
+                        self.clear_interrupts();
+                        self.enable_interrupts(interrupts);
                     }
                 }
 
-                impl<I: Instance> $name<I> {
-                    #[inline(always)]
-                    pub fn clear_half_transfer_interrupt(&mut self) {
-                        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                        // that belongs to the StreamX
-                        let dma = unsafe { &*I::ptr() };
-                        dma.ifcr().write(|w| w.[<chtif $x>]().set_bit());
-                        let _ = dma.isr().read();
-                        let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                    }
-
-                    #[inline(always)]
-                    pub fn get_half_transfer_flag() -> bool {
-                        //NOTE(unsafe) Atomic read with no side effects
-                        let dma = unsafe { &*I::ptr() };
-                        dma.isr().read().[<htif $x>]().bit_is_set()
-                    }
-
-                    #[inline(always)]
-                    pub fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
-                        //NOTE(unsafe) We only access the registers that belongs to the StreamX
-                        let dmacr = &unsafe { &*I::ptr() }.[<ch $x>]().cr();
-                        dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                        let _ = dmacr.read();
-                        let _ = dmacr.read(); // Delay 2 peripheral clocks
+                #[inline(always)]
+                fn set_request_line(&mut self, request_line: u8) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dmamux = unsafe { &*I::mux_ptr() };
+                    unsafe {
+                        dmamux.ccr($number)
+                            .modify(|_, w| w.dmareq_id().bits(request_line));
                     }
                 }
-            )+
-        }
+
+                #[inline(always)]
+                fn set_priority(&mut self, priority: config::Priority) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| unsafe { w.pl().bits(priority.bits()) });
+                }
+
+                #[inline(always)]
+                fn disable_interrupts(&mut self) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
+                    dmacr.modify(|_, w| w
+                        .tcie().clear_bit()
+                        .teie().clear_bit()
+                        .htie().clear_bit());
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
+                }
+
+                #[inline(always)]
+                fn enable_interrupts(&mut self, interrupt: Self::Interrupts) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| w
+                        .tcie().bit(interrupt.transfer_complete)
+                        .teie().bit(interrupt.transfer_error)
+                        .htie().bit(interrupt.half_transfer)
+                    );
+                }
+
+                #[inline(always)]
+                fn get_interrupts_enable() -> Self::Interrupts {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    let cr = dma_ch.cr().read();
+
+                    DmaInterrupts {
+                        transfer_complete: cr.tcie().bit_is_set(),
+                        half_transfer: cr.htie().bit_is_set(),
+                        transfer_error: cr.teie().bit_is_set()
+                    }
+                }
+
+
+                #[inline(always)]
+                fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
+                    dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
+                }
+
+                #[inline(always)]
+                fn set_transfer_error_interrupt_enable(&mut self, transfer_error_interrupt: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
+                    dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
+                }
+
+                #[inline(always)]
+                fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
+                    dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
+                }
+
+                #[inline(always)]
+                fn get_half_transfer_flag() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let dma = unsafe { &*I::ptr() };
+                    dma.isr().read().htif(Self::NUMBER as u8).bit_is_set()
+                }
+
+                #[inline(always)]
+                fn clear_half_transfer_interrupt(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let dma = unsafe { &*I::ptr() };
+                    dma.ifcr().write(|w| w.chtif(Self::NUMBER as u8).set_bit());
+                    let _ = dma.isr().read();
+                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                }
+
+                #[inline(always)]
+                unsafe fn set_peripheral_address(&mut self, value: u32) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.par().write(|w| w.pa().bits(value));
+                }
+
+                #[inline(always)]
+                unsafe fn set_memory_address(&mut self, value: u32) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.mar().write(|w| w.ma().bits(value) );
+                }
+
+                #[inline(always)]
+                fn get_memory_address(&self) -> u32 {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.mar().read().ma().bits()
+                }
+
+                #[inline(always)]
+                fn set_number_of_transfers(&mut self, value: u16) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.ndtr().write(|w| unsafe {w.ndt().bits(value) });
+                }
+
+                #[inline(always)]
+                fn get_number_of_transfers() -> u16 {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.ndtr().read().ndt().bits()
+                }
+                #[inline(always)]
+                unsafe fn set_memory_size(&mut self, size: u8) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| w.msize().bits(size));
+                }
+
+                #[inline(always)]
+                unsafe fn set_peripheral_size(&mut self, size: u8) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| w.psize().bits(size));
+                }
+
+                #[inline(always)]
+                fn set_memory_increment(&mut self, increment: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| w.minc().bit(increment));
+                }
+
+                #[inline(always)]
+                fn set_peripheral_increment(&mut self, increment: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| w.pinc().bit(increment));
+                }
+
+                #[inline(always)]
+                fn set_direction(&mut self, direction: DmaDirection) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| {
+                        match direction {
+                            DmaDirection::PeripheralToMemory =>
+                                w.dir().clear_bit().mem2mem().clear_bit(),
+                            DmaDirection::MemoryToPeripheral =>
+                                w.dir().set_bit().mem2mem().clear_bit(),
+                            DmaDirection::MemoryToMemory =>
+                                w.mem2mem().set_bit().dir().clear_bit(),
+                        }
+                    });
+                }
+
+                #[inline(always)]
+                fn set_circular_buffer(&mut self, circular_buffer: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
+                    dma_ch.cr().modify(|_, w| w.circ().bit(circular_buffer));
+                }
+            }
+
+            impl<I: Instance> $name<I> {
+                #[inline(always)]
+                pub fn clear_half_transfer_interrupt(&mut self) {
+                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+                    // that belongs to the StreamX
+                    let dma = unsafe { &*I::ptr() };
+                    dma.ifcr().write(|w| w.chtif(Self::NUMBER as u8).set_bit());
+                    let _ = dma.isr().read();
+                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
+                }
+
+                #[inline(always)]
+                pub fn get_half_transfer_flag() -> bool {
+                    //NOTE(unsafe) Atomic read with no side effects
+                    let dma = unsafe { &*I::ptr() };
+                    dma.isr().read().htif(Self::NUMBER as u8).bit_is_set()
+                }
+
+                #[inline(always)]
+                pub fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
+                    //NOTE(unsafe) We only access the registers that belongs to the StreamX
+                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
+                    dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+                    let _ = dmacr.read();
+                    let _ = dmacr.read(); // Delay 2 peripheral clocks
+                }
+            }
+        )+
     };
 }
 

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -88,14 +88,18 @@ impl ExtiExt for EXTI {
         let mask = 1 << line;
         match edge {
             SignalEdge::Rising => {
-                self.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+                self.rtsr1()
+                    .modify(|r, w| unsafe { w.bits(r.bits() | mask) });
             }
             SignalEdge::Falling => {
-                self.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+                self.ftsr1()
+                    .modify(|r, w| unsafe { w.bits(r.bits() | mask) });
             }
             SignalEdge::RisingFalling => {
-                self.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() | mask) });
-                self.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+                self.rtsr1()
+                    .modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+                self.ftsr1()
+                    .modify(|r, w| unsafe { w.bits(r.bits() | mask) });
             }
         }
         self.wakeup(ev);
@@ -104,10 +108,10 @@ impl ExtiExt for EXTI {
     fn wakeup(&self, ev: Event) {
         match ev as u8 {
             line if line < 32 => self
-                .imr1
+                .imr1()
                 .modify(|r, w| unsafe { w.bits(r.bits() | 1 << line) }),
             line => self
-                .imr2
+                .imr2()
                 .modify(|r, w| unsafe { w.bits(r.bits() | 1 << (line - 32)) }),
         }
     }
@@ -117,15 +121,19 @@ impl ExtiExt for EXTI {
         match ev as u8 {
             line if line < 32 => {
                 let mask = !(1 << line);
-                self.imr1.modify(|r, w| unsafe { w.bits(r.bits() & mask) });
+                self.imr1()
+                    .modify(|r, w| unsafe { w.bits(r.bits() & mask) });
                 if line <= 18 {
-                    self.rtsr1.modify(|r, w| unsafe { w.bits(r.bits() & mask) });
-                    self.ftsr1.modify(|r, w| unsafe { w.bits(r.bits() & mask) });
+                    self.rtsr1()
+                        .modify(|r, w| unsafe { w.bits(r.bits() & mask) });
+                    self.ftsr1()
+                        .modify(|r, w| unsafe { w.bits(r.bits() & mask) });
                 }
             }
             line => {
                 let mask = !(1 << (line - 32));
-                self.imr2.modify(|r, w| unsafe { w.bits(r.bits() & mask) })
+                self.imr2()
+                    .modify(|r, w| unsafe { w.bits(r.bits() & mask) })
             }
         }
     }
@@ -136,13 +144,13 @@ impl ExtiExt for EXTI {
             return false;
         }
         let mask = 1 << line;
-        self.pr1.read().bits() & mask != 0
+        self.pr1().read().bits() & mask != 0
     }
 
     fn unpend(&self, ev: Event) {
         let line = ev as u8;
         if line <= 18 {
-            self.pr1.modify(|_, w| unsafe { w.bits(1 << line) });
+            self.pr1().modify(|_, w| unsafe { w.bits(1 << line) });
         }
     }
 }

--- a/src/exti.rs
+++ b/src/exti.rs
@@ -113,7 +113,7 @@ impl ExtiExt for EXTI {
             line => self
                 .imr2()
                 .modify(|r, w| unsafe { w.bits(r.bits() | 1 << (line - 32)) }),
-        }
+        };
     }
 
     fn unlisten(&self, ev: Event) {
@@ -133,7 +133,7 @@ impl ExtiExt for EXTI {
             line => {
                 let mask = !(1 << (line - 32));
                 self.imr2()
-                    .modify(|r, w| unsafe { w.bits(r.bits() & mask) })
+                    .modify(|r, w| unsafe { w.bits(r.bits() & mask) });
             }
         }
     }

--- a/src/fdcan.rs
+++ b/src/fdcan.rs
@@ -1712,7 +1712,7 @@ mod impls {
         feature = "stm32g483",
         feature = "stm32g484",
         feature = "stm32g491",
-        feature = "stm32g4A1",
+        feature = "stm32g4a1",
     ))]
     mod fdcan2 {
         use crate::fdcan;

--- a/src/fdcan.rs
+++ b/src/fdcan.rs
@@ -1159,10 +1159,11 @@ where
     #[inline]
     pub fn error_counters(&self) -> ErrorCounters {
         let can = self.registers();
-        let cel: u8 = can.ecr().read().cel().bits();
-        let rp: bool = can.ecr().read().rp().bit();
-        let rec: u8 = can.ecr().read().rec().bits();
-        let tec: u8 = can.ecr().read().tec().bits();
+        let ecr = can.ecr().read();
+        let cel: u8 = ecr.cel().bits();
+        let rp: bool = ecr.rp().bit();
+        let rec: u8 = ecr.rec().bits();
+        let tec: u8 = ecr.tec().bits();
 
         ErrorCounters {
             can_errors: cel,

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -465,7 +465,7 @@ pub struct ACR {
 impl ACR {
     pub(crate) fn acr(&mut self) -> &flash::ACR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).acr }
+        unsafe { &(*FLASH::ptr()).acr() }
     }
 }
 
@@ -478,7 +478,7 @@ pub struct CR {
 impl CR {
     pub(crate) fn cr(&mut self) -> &flash::CR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).cr }
+        unsafe { &(*FLASH::ptr()).cr() }
     }
 }
 
@@ -491,7 +491,7 @@ pub struct ECCR {
 impl ECCR {
     pub(crate) fn eccr(&mut self) -> &flash::ECCR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).eccr }
+        unsafe { &(*FLASH::ptr()).eccr() }
     }
 }
 
@@ -504,7 +504,7 @@ pub struct KEYR {
 impl KEYR {
     pub(crate) fn keyr(&mut self) -> &flash::KEYR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).keyr }
+        unsafe { &(*FLASH::ptr()).keyr() }
     }
 }
 
@@ -517,7 +517,7 @@ pub struct OPTKEYR {
 impl OPTKEYR {
     pub(crate) fn optkeyr(&mut self) -> &flash::OPTKEYR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).optkeyr }
+        unsafe { &(*FLASH::ptr()).optkeyr() }
     }
 }
 
@@ -530,7 +530,7 @@ pub struct OPTR {
 impl OPTR {
     pub(crate) fn optr(&mut self) -> &flash::OPTR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).optr }
+        unsafe { &(*FLASH::ptr()).optr() }
     }
 }
 
@@ -543,7 +543,7 @@ pub struct PCROP1SR {
 impl PCROP1SR {
     pub(crate) fn pcrop1sr(&mut self) -> &flash::PCROP1SR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).pcrop1sr }
+        unsafe { &(*FLASH::ptr()).pcrop1sr() }
     }
 }
 
@@ -556,7 +556,7 @@ pub struct PCROP1ER {
 impl PCROP1ER {
     pub(crate) fn pcrop1er(&mut self) -> &flash::PCROP1ER {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).pcrop1er }
+        unsafe { &(*FLASH::ptr()).pcrop1er() }
     }
 }
 
@@ -569,7 +569,7 @@ pub struct PDKEYR {
 impl PDKEYR {
     pub(crate) fn pdkeyr(&mut self) -> &flash::PDKEYR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).pdkeyr }
+        unsafe { &(*FLASH::ptr()).pdkeyr() }
     }
 }
 
@@ -582,7 +582,7 @@ pub struct SEC1R {
 impl SEC1R {
     pub(crate) fn sec1r(&mut self) -> &flash::SEC1R {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).sec1r }
+        unsafe { &(*FLASH::ptr()).sec1r() }
     }
 }
 
@@ -595,7 +595,7 @@ pub struct SR {
 impl SR {
     pub(crate) fn sr(&mut self) -> &flash::SR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).sr }
+        unsafe { &(*FLASH::ptr()).sr() }
     }
 }
 
@@ -608,7 +608,7 @@ pub struct WRP1AR {
 impl WRP1AR {
     pub(crate) fn wrp1ar(&mut self) -> &flash::WRP1AR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).wrp1ar }
+        unsafe { &(*FLASH::ptr()).wrp1ar() }
     }
 }
 
@@ -621,6 +621,6 @@ pub struct WRP1BR {
 impl WRP1BR {
     pub(crate) fn wrp1br(&mut self) -> &flash::WRP1BR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).wrp1br }
+        unsafe { &(*FLASH::ptr()).wrp1br() }
     }
 }

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -465,7 +465,7 @@ pub struct ACR {
 impl ACR {
     pub(crate) fn acr(&mut self) -> &flash::ACR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).acr() }
+        unsafe { (*FLASH::ptr()).acr() }
     }
 }
 
@@ -478,7 +478,7 @@ pub struct CR {
 impl CR {
     pub(crate) fn cr(&mut self) -> &flash::CR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).cr() }
+        unsafe { (*FLASH::ptr()).cr() }
     }
 }
 
@@ -491,7 +491,7 @@ pub struct ECCR {
 impl ECCR {
     pub(crate) fn eccr(&mut self) -> &flash::ECCR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).eccr() }
+        unsafe { (*FLASH::ptr()).eccr() }
     }
 }
 
@@ -504,7 +504,7 @@ pub struct KEYR {
 impl KEYR {
     pub(crate) fn keyr(&mut self) -> &flash::KEYR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).keyr() }
+        unsafe { (*FLASH::ptr()).keyr() }
     }
 }
 
@@ -517,7 +517,7 @@ pub struct OPTKEYR {
 impl OPTKEYR {
     pub(crate) fn optkeyr(&mut self) -> &flash::OPTKEYR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).optkeyr() }
+        unsafe { (*FLASH::ptr()).optkeyr() }
     }
 }
 
@@ -530,7 +530,7 @@ pub struct OPTR {
 impl OPTR {
     pub(crate) fn optr(&mut self) -> &flash::OPTR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).optr() }
+        unsafe { (*FLASH::ptr()).optr() }
     }
 }
 
@@ -543,7 +543,7 @@ pub struct PCROP1SR {
 impl PCROP1SR {
     pub(crate) fn pcrop1sr(&mut self) -> &flash::PCROP1SR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).pcrop1sr() }
+        unsafe { (*FLASH::ptr()).pcrop1sr() }
     }
 }
 
@@ -556,7 +556,7 @@ pub struct PCROP1ER {
 impl PCROP1ER {
     pub(crate) fn pcrop1er(&mut self) -> &flash::PCROP1ER {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).pcrop1er() }
+        unsafe { (*FLASH::ptr()).pcrop1er() }
     }
 }
 
@@ -569,7 +569,7 @@ pub struct PDKEYR {
 impl PDKEYR {
     pub(crate) fn pdkeyr(&mut self) -> &flash::PDKEYR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).pdkeyr() }
+        unsafe { (*FLASH::ptr()).pdkeyr() }
     }
 }
 
@@ -582,7 +582,7 @@ pub struct SEC1R {
 impl SEC1R {
     pub(crate) fn sec1r(&mut self) -> &flash::SEC1R {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).sec1r() }
+        unsafe { (*FLASH::ptr()).sec1r() }
     }
 }
 
@@ -595,7 +595,7 @@ pub struct SR {
 impl SR {
     pub(crate) fn sr(&mut self) -> &flash::SR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).sr() }
+        unsafe { (*FLASH::ptr()).sr() }
     }
 }
 
@@ -608,7 +608,7 @@ pub struct WRP1AR {
 impl WRP1AR {
     pub(crate) fn wrp1ar(&mut self) -> &flash::WRP1AR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).wrp1ar() }
+        unsafe { (*FLASH::ptr()).wrp1ar() }
     }
 }
 
@@ -621,6 +621,6 @@ pub struct WRP1BR {
 impl WRP1BR {
     pub(crate) fn wrp1br(&mut self) -> &flash::WRP1BR {
         // NOTE(unsafe) this proxy grants exclusive access to this register
-        unsafe { &(*FLASH::ptr()).wrp1br() }
+        unsafe { (*FLASH::ptr()).wrp1br() }
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -99,22 +99,22 @@ macro_rules! exti_erased {
                 let offset = 4 * (self.i % 4);
                 match self.i {
                     0..=3 => {
-                        syscfg.exticr1.modify(|r, w| unsafe {
+                        syscfg.exticr1().modify(|r, w| unsafe {
                             w.bits((r.bits() & !(0xf << offset)) | ($extigpionr << offset))
                         });
                     }
                     4..=7 => {
-                        syscfg.exticr2.modify(|r, w| unsafe {
+                        syscfg.exticr2().modify(|r, w| unsafe {
                             w.bits((r.bits() & !(0xf << offset)) | ($extigpionr << offset))
                         });
                     }
                     8..=11 => {
-                        syscfg.exticr3.modify(|r, w| unsafe {
+                        syscfg.exticr3().modify(|r, w| unsafe {
                             w.bits((r.bits() & !(0xf << offset)) | ($extigpionr << offset))
                         });
                     }
                     12..=15 => {
-                        syscfg.exticr4.modify(|r, w| unsafe {
+                        syscfg.exticr4().modify(|r, w| unsafe {
                             w.bits((r.bits() & !(0xf << offset)) | ($extigpionr << offset))
                         });
                     }
@@ -126,21 +126,21 @@ macro_rules! exti_erased {
             fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: SignalEdge) {
                 match edge {
                     SignalEdge::Rising => {
-                        exti.rtsr1
+                        exti.rtsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
-                        exti.ftsr1
+                        exti.ftsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                     }
                     SignalEdge::Falling => {
-                        exti.ftsr1
+                        exti.ftsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
-                        exti.rtsr1
+                        exti.rtsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
                     }
                     SignalEdge::RisingFalling => {
-                        exti.rtsr1
+                        exti.rtsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
-                        exti.ftsr1
+                        exti.ftsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
                     }
                 }
@@ -148,24 +148,24 @@ macro_rules! exti_erased {
 
             /// Enable external interrupts from this pin.
             fn enable_interrupt(&mut self, exti: &mut EXTI) {
-                exti.imr1
+                exti.imr1()
                     .modify(|r, w| unsafe { w.bits(r.bits() | (1 << self.i)) });
             }
 
             /// Disable external interrupts from this pin
             fn disable_interrupt(&mut self, exti: &mut EXTI) {
-                exti.imr1
+                exti.imr1()
                     .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << self.i)) });
             }
 
             /// Clear the interrupt pending bit for this pin
             fn clear_interrupt_pending_bit(&mut self) {
-                unsafe { (*EXTI::ptr()).pr1.write(|w| w.bits(1 << self.i)) };
+                unsafe { (*EXTI::ptr()).pr1().write(|w| w.bits(1 << self.i)) };
             }
 
             /// Reads the interrupt pending bit for this pin
             fn check_interrupt(&self) -> bool {
-                unsafe { ((*EXTI::ptr()).pr1.read().bits() & (1 << self.i)) != 0 }
+                unsafe { ((*EXTI::ptr()).pr1().read().bits() & (1 << self.i)) != 0 }
             }
         }
     };
@@ -177,7 +177,7 @@ macro_rules! exti {
             /// Configure EXTI Line $i to trigger from this pin.
             fn make_interrupt_source(&mut self, syscfg: &mut SysCfg) {
                 let offset = 4 * ($i % 4);
-                syscfg.$exticri.modify(|r, w| unsafe {
+                syscfg.$exticri().modify(|r, w| unsafe {
                     let mut exticr = r.bits();
                     exticr = (exticr & !(0xf << offset)) | ($extigpionr << offset); //FIXME: clears other pins
                     w.bits(exticr)
@@ -188,21 +188,21 @@ macro_rules! exti {
             fn trigger_on_edge(&mut self, exti: &mut EXTI, edge: SignalEdge) {
                 match edge {
                     SignalEdge::Rising => {
-                        exti.rtsr1
+                        exti.rtsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
-                        exti.ftsr1
+                        exti.ftsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                     }
                     SignalEdge::Falling => {
-                        exti.ftsr1
+                        exti.ftsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
-                        exti.rtsr1
+                        exti.rtsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
                     }
                     SignalEdge::RisingFalling => {
-                        exti.rtsr1
+                        exti.rtsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
-                        exti.ftsr1
+                        exti.ftsr1()
                             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
                     }
                 }
@@ -210,24 +210,24 @@ macro_rules! exti {
 
             /// Enable external interrupts from this pin.
             fn enable_interrupt(&mut self, exti: &mut EXTI) {
-                exti.imr1
+                exti.imr1()
                     .modify(|r, w| unsafe { w.bits(r.bits() | (1 << $i)) });
             }
 
             /// Disable external interrupts from this pin
             fn disable_interrupt(&mut self, exti: &mut EXTI) {
-                exti.imr1
+                exti.imr1()
                     .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << $i)) });
             }
 
             /// Clear the interrupt pending bit for this pin
             fn clear_interrupt_pending_bit(&mut self) {
-                unsafe { (*EXTI::ptr()).pr1.write(|w| w.bits(1 << $i)) };
+                unsafe { (*EXTI::ptr()).pr1().write(|w| w.bits(1 << $i)) };
             }
 
             /// Reads the interrupt pending bit for this pin
             fn check_interrupt(&self) -> bool {
-                unsafe { ((*EXTI::ptr()).pr1.read().bits() & (1 << $i)) != 0 }
+                unsafe { ((*EXTI::ptr()).pr1().read().bits() & (1 << $i)) != 0 }
             }
         }
     };
@@ -257,7 +257,7 @@ macro_rules! gpio {
                 type Parts = Parts;
 
                 fn split(self, rcc: &mut Rcc) -> Parts {
-                    rcc.rb.ahb2enr.modify(|_, w| w.$iopxenr().set_bit());
+                    rcc.rb.ahb2enr().modify(|_, w| w.$iopxenr().set_bit());
                     Parts {
                         $(
                             $pxi: $PXi { _mode: PhantomData },
@@ -277,13 +277,13 @@ macro_rules! gpio {
 
                 fn set_high(&mut self) -> Result<(), ()> {
                     // NOTE(unsafe) atomic write to a stateless register
-                    unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << self.i)) };
+                    unsafe { (*$GPIOX::ptr()).bsrr().write(|w| w.bits(1 << self.i)) };
                     Ok(())
                 }
 
                 fn set_low(&mut self) -> Result<(), ()> {
                     // NOTE(unsafe) atomic write to a stateless register
-                    unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << (self.i + 16))) };
+                    unsafe { (*$GPIOX::ptr()).bsrr().write(|w| w.bits(1 << (self.i + 16))) };
                     Ok(())
                 }
             }
@@ -296,7 +296,7 @@ macro_rules! gpio {
 
                 fn is_set_low(&self) -> Result<bool, ()> {
                     // NOTE(unsafe) atomic read with no side effects
-                    let is_set_low = unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << self.i) == 0 };
+                    let is_set_low = unsafe { (*$GPIOX::ptr()).odr().read().bits() & (1 << self.i) == 0 };
                     Ok(is_set_low)
                 }
             }
@@ -314,7 +314,7 @@ macro_rules! gpio {
 
                 fn is_low(&self) -> Result<bool, ()>  {
                     // NOTE(unsafe) atomic read with no side effects
-                    let is_low = unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 };
+                    let is_low = unsafe { (*$GPIOX::ptr()).idr().read().bits() & (1 << self.i) == 0 };
                     Ok(is_low)
                 }
             }
@@ -329,7 +329,7 @@ macro_rules! gpio {
 
                 fn is_low(&self) -> Result<bool, ()> {
                     // NOTE(unsafe) atomic read with no side effects
-                    let is_low = unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 };
+                    let is_low = unsafe { (*$GPIOX::ptr()).idr().read().bits() & (1 << self.i) == 0 };
                     Ok(is_low)
                 }
             }
@@ -385,10 +385,10 @@ macro_rules! gpio {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
-                            gpio.pupdr.modify(|r, w| {
+                            gpio.pupdr().modify(|r, w| {
                                 w.bits(r.bits() & !(0b11 << offset))
                             });
-                            gpio.moder.modify(|r, w| {
+                            gpio.moder().modify(|r, w| {
                                 w.bits(r.bits() & !(0b11 << offset))
                             })
                         };
@@ -400,10 +400,10 @@ macro_rules! gpio {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
-                            gpio.pupdr.modify(|r, w| {
+                            gpio.pupdr().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b10 << offset))
                             });
-                            gpio.moder.modify(|r, w| {
+                            gpio.moder().modify(|r, w| {
                                 w.bits(r.bits() & !(0b11 << offset))
                             })
                         };
@@ -415,10 +415,10 @@ macro_rules! gpio {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
-                            gpio.pupdr.modify(|r, w| {
+                            gpio.pupdr().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b01 << offset))
                             });
-                            gpio.moder.modify(|r, w| {
+                            gpio.moder().modify(|r, w| {
                                 w.bits(r.bits() & !(0b11 << offset))
                             })
                         };
@@ -430,10 +430,10 @@ macro_rules! gpio {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
-                            gpio.pupdr.modify(|r, w| {
+                            gpio.pupdr().modify(|r, w| {
                                 w.bits(r.bits() & !(0b11 << offset))
                             });
-                            gpio.moder.modify(|r, w| {
+                            gpio.moder().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b11 << offset))
                             });
                         }
@@ -445,13 +445,13 @@ macro_rules! gpio {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
-                            gpio.pupdr.modify(|r, w| {
+                            gpio.pupdr().modify(|r, w| {
                                 w.bits(r.bits() & !(0b11 << offset))
                             });
-                            gpio.otyper.modify(|r, w| {
+                            gpio.otyper().modify(|r, w| {
                                 w.bits(r.bits() | (0b1 << $i))
                             });
-                            gpio.moder.modify(|r, w| {
+                            gpio.moder().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b01 << offset))
                             })
                         };
@@ -463,13 +463,13 @@ macro_rules! gpio {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
-                            gpio.pupdr.modify(|r, w| {
+                            gpio.pupdr().modify(|r, w| {
                                 w.bits(r.bits() & !(0b11 << offset))
                             });
-                            gpio.otyper.modify(|r, w| {
+                            gpio.otyper().modify(|r, w| {
                                 w.bits(r.bits() & !(0b1 << $i))
                             });
-                            gpio.moder.modify(|r, w| {
+                            gpio.moder().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b01 << offset))
                             })
                         };
@@ -486,7 +486,7 @@ macro_rules! gpio {
                     pub fn set_speed(self, speed: Speed) -> Self {
                         let offset = 2 * $i;
                         unsafe {
-                            (*$GPIOX::ptr()).ospeedr.modify(|r, w| {
+                            (*$GPIOX::ptr()).ospeedr().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | ((speed as u32) << offset))
                             })
                         }
@@ -500,19 +500,19 @@ macro_rules! gpio {
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
                             if offset2 < 32 {
-                                gpio.afrl.modify(|r, w| {
+                                gpio.afrl().modify(|r, w| {
                                     w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                                 });
                             } else {
                                 let offset2 = offset2 - 32;
-                                gpio.afrh.modify(|r, w| {
+                                gpio.afrh().modify(|r, w| {
                                     w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                                 });
                             }
-                            gpio.moder.modify(|r, w| {
+                            gpio.moder().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b10 << offset))
                             });
-                            gpio.otyper.modify(|r, w| {
+                            gpio.otyper().modify(|r, w| {
                                 w.bits(r.bits() & !(0b1 << $i))
                             });
                         }
@@ -526,19 +526,19 @@ macro_rules! gpio {
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
                             if offset2 < 32 {
-                                gpio.afrl.modify(|r, w| {
+                                gpio.afrl().modify(|r, w| {
                                     w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                                 });
                             } else {
                                 let offset2 = offset2 - 32;
-                                gpio.afrh.modify(|r, w| {
+                                gpio.afrh().modify(|r, w| {
                                     w.bits((r.bits() & !(0b1111 << offset2)) | (mode << offset2))
                                 });
                             }
-                            gpio.otyper.modify(|r, w| {
+                            gpio.otyper().modify(|r, w| {
                                 w.bits(r.bits() | (0b1 << $i))
                             });
-                            gpio.moder.modify(|r, w| {
+                            gpio.moder().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | (0b10 << offset))
                             });
                         }
@@ -561,13 +561,13 @@ macro_rules! gpio {
 
                     fn set_high(&mut self) -> Result<(), ()> {
                         // NOTE(unsafe) atomic write to a stateless register
-                        unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) };
+                        unsafe { (*$GPIOX::ptr()).bsrr().write(|w| w.bits(1 << $i)) };
                         Ok(())
                     }
 
                     fn set_low(&mut self) -> Result<(), ()>{
                         // NOTE(unsafe) atomic write to a stateless register
-                        unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << ($i + 16))) };
+                        unsafe { (*$GPIOX::ptr()).bsrr().write(|w| w.bits(1 << ($i + 16))) };
                         Ok(())
                     }
                 }
@@ -580,7 +580,7 @@ macro_rules! gpio {
 
                     fn is_set_low(&self) -> Result<bool, ()> {
                         // NOTE(unsafe) atomic read with no side effects
-                        let is_set_low = unsafe { (*$GPIOX::ptr()).odr.read().bits() & (1 << $i) == 0 };
+                        let is_set_low = unsafe { (*$GPIOX::ptr()).odr().read().bits() & (1 << $i) == 0 };
                         Ok(is_set_low)
                     }
                 }
@@ -598,7 +598,7 @@ macro_rules! gpio {
 
                     fn is_low(&self) -> Result<bool, ()>  {
                         // NOTE(unsafe) atomic read with no side effects
-                        let is_low = unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 };
+                        let is_low = unsafe { (*$GPIOX::ptr()).idr().read().bits() & (1 << $i) == 0 };
                         Ok(is_low)
                     }
                 }
@@ -623,7 +623,7 @@ macro_rules! gpio {
 
                     fn is_low(&self) -> Result<bool, ()> {
                         // NOTE(unsafe) atomic read with no side effects
-                        let is_low = unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 };
+                        let is_low = unsafe { (*$GPIOX::ptr()).idr().read().bits() & (1 << $i) == 0 };
                         Ok(is_low)
                     }
                 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -488,7 +488,7 @@ macro_rules! gpio {
                         unsafe {
                             (*$GPIOX::ptr()).ospeedr().modify(|r, w| {
                                 w.bits((r.bits() & !(0b11 << offset)) | ((speed as u32) << offset))
-                            })
+                            });
                         }
                         self
                     }

--- a/src/independent_watchdog.rs
+++ b/src/independent_watchdog.rs
@@ -93,7 +93,7 @@ impl IndependentWatchdog {
         }
         self.iwdg
             .winr()
-            .write(|w| unsafe { w.win().bits(Self::MAX_COUNTER_VALUE as u16) } );
+            .write(|w| unsafe { w.win().bits(Self::MAX_COUNTER_VALUE as u16) });
 
         // Calculate the counter values
         let reload_value = max_window_time.to_millis() * (Self::CLOCK_SPEED / 1000)
@@ -105,7 +105,9 @@ impl IndependentWatchdog {
         while self.iwdg.sr().read().rvu().bit_is_set() {
             cortex_m::asm::nop();
         }
-        self.iwdg.rlr().write(|w| unsafe { w.rl().bits(reload_value as u16) });
+        self.iwdg
+            .rlr()
+            .write(|w| unsafe { w.rl().bits(reload_value as u16) });
 
         self.feed();
         // Enable register access

--- a/src/independent_watchdog.rs
+++ b/src/independent_watchdog.rs
@@ -12,7 +12,7 @@
 //!
 //! Originally from stm32h7-hal, adapted for stm32g4xx-hal
 use crate::{
-    stm32::{iwdg::pr::PR_A, IWDG},
+    stm32::{iwdg::pr::PR, IWDG},
     time::MicroSecond,
 };
 use fugit::ExtU32;
@@ -25,37 +25,33 @@ pub struct IndependentWatchdog {
 impl IndependentWatchdog {
     const CLOCK_SPEED: u32 = 32000;
     const MAX_COUNTER_VALUE: u32 = 0x00000FFF;
-    const MAX_MILLIS_FOR_PRESCALER: [(PR_A, u32); 8] = [
+    const MAX_MILLIS_FOR_PRESCALER: [(PR, u32); 7] = [
         (
-            PR_A::DivideBy4,
+            PR::DivideBy4,
             (Self::MAX_COUNTER_VALUE * 1000) / (Self::CLOCK_SPEED / 4),
         ),
         (
-            PR_A::DivideBy8,
+            PR::DivideBy8,
             (Self::MAX_COUNTER_VALUE * 1000) / (Self::CLOCK_SPEED / 8),
         ),
         (
-            PR_A::DivideBy16,
+            PR::DivideBy16,
             (Self::MAX_COUNTER_VALUE * 1000) / (Self::CLOCK_SPEED / 16),
         ),
         (
-            PR_A::DivideBy32,
+            PR::DivideBy32,
             (Self::MAX_COUNTER_VALUE * 1000) / (Self::CLOCK_SPEED / 32),
         ),
         (
-            PR_A::DivideBy64,
+            PR::DivideBy64,
             (Self::MAX_COUNTER_VALUE * 1000) / (Self::CLOCK_SPEED / 64),
         ),
         (
-            PR_A::DivideBy128,
+            PR::DivideBy128,
             (Self::MAX_COUNTER_VALUE * 1000) / (Self::CLOCK_SPEED / 128),
         ),
         (
-            PR_A::DivideBy256,
-            (Self::MAX_COUNTER_VALUE * 1000) / (Self::CLOCK_SPEED / 256),
-        ),
-        (
-            PR_A::DivideBy256bis,
+            PR::DivideBy256,
             (Self::MAX_COUNTER_VALUE * 1000) / (Self::CLOCK_SPEED / 256),
         ),
     ];
@@ -67,7 +63,7 @@ impl IndependentWatchdog {
 
     /// Feed the watchdog, resetting the timer to 0
     pub fn feed(&mut self) {
-        self.iwdg.kr.write(|w| w.key().reset());
+        self.iwdg.kr().write(|w| w.key().feed());
     }
 
     /// Start the watchdog where it must be fed before the max time is over and
@@ -77,27 +73,27 @@ impl IndependentWatchdog {
         let max_window_time: MicroSecond = max_window_time.into();
 
         // Start the watchdog
-        self.iwdg.kr.write(|w| w.key().start());
+        self.iwdg.kr().write(|w| w.key().start());
         // Enable register access
-        self.iwdg.kr.write(|w| w.key().enable());
+        self.iwdg.kr().write(|w| w.key().unlock());
 
         // Set the prescaler
         let (prescaler, _) = Self::MAX_MILLIS_FOR_PRESCALER
             .iter()
             .find(|(_, max_millis)| *max_millis >= max_window_time.to_millis())
             .expect("IWDG max time is greater than is possible");
-        while self.iwdg.sr.read().pvu().bit_is_set() {
+        while self.iwdg.sr().read().pvu().bit_is_set() {
             cortex_m::asm::nop();
         }
-        self.iwdg.pr.write(|w| w.pr().variant(*prescaler));
+        self.iwdg.pr().write(|w| w.pr().variant(*prescaler));
 
         // Reset the window value
-        while self.iwdg.sr.read().wvu().bit_is_set() {
+        while self.iwdg.sr().read().wvu().bit_is_set() {
             cortex_m::asm::nop();
         }
         self.iwdg
-            .winr
-            .write(|w| w.win().bits(Self::MAX_COUNTER_VALUE as u16));
+            .winr()
+            .write(|w| unsafe { w.win().bits(Self::MAX_COUNTER_VALUE as u16) } );
 
         // Calculate the counter values
         let reload_value = max_window_time.to_millis() * (Self::CLOCK_SPEED / 1000)
@@ -106,25 +102,25 @@ impl IndependentWatchdog {
             / Self::get_prescaler_divider(prescaler);
 
         // Set the reload value
-        while self.iwdg.sr.read().rvu().bit_is_set() {
+        while self.iwdg.sr().read().rvu().bit_is_set() {
             cortex_m::asm::nop();
         }
-        self.iwdg.rlr.write(|w| w.rl().bits(reload_value as u16));
+        self.iwdg.rlr().write(|w| unsafe { w.rl().bits(reload_value as u16) });
 
         self.feed();
         // Enable register access
-        self.iwdg.kr.write(|w| w.key().enable());
+        self.iwdg.kr().write(|w| w.key().unlock());
 
         // Set the window value
-        while self.iwdg.sr.read().wvu().bit_is_set() {
+        while self.iwdg.sr().read().wvu().bit_is_set() {
             cortex_m::asm::nop();
         }
         self.iwdg
-            .winr
-            .write(|w| w.win().bits((reload_value - window_value) as u16));
+            .winr()
+            .write(|w| unsafe { w.win().bits((reload_value - window_value) as u16) });
 
         // Wait until everything is set
-        while self.iwdg.sr.read().bits() != 0 {
+        while self.iwdg.sr().read().bits() != 0 {
             cortex_m::asm::nop();
         }
 
@@ -136,16 +132,15 @@ impl IndependentWatchdog {
         self.start_windowed(0_u32.millis(), max_time.into());
     }
 
-    fn get_prescaler_divider(prescaler: &PR_A) -> u32 {
+    fn get_prescaler_divider(prescaler: &PR) -> u32 {
         match prescaler {
-            PR_A::DivideBy4 => 4,
-            PR_A::DivideBy8 => 8,
-            PR_A::DivideBy16 => 16,
-            PR_A::DivideBy32 => 32,
-            PR_A::DivideBy64 => 64,
-            PR_A::DivideBy128 => 128,
-            PR_A::DivideBy256 => 256,
-            PR_A::DivideBy256bis => 256,
+            PR::DivideBy4 => 4,
+            PR::DivideBy8 => 8,
+            PR::DivideBy16 => 16,
+            PR::DivideBy32 => 32,
+            PR::DivideBy64 => 64,
+            PR::DivideBy128 => 128,
+            PR::DivideBy256 => 256,
         }
     }
 }

--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -864,7 +864,8 @@ macro_rules! opamps {
     };
 }
 
-#[cfg(any(feature = "stm32g431", feature = "stm32g441", feature = "stm32g471",))]
+// TODO: Figure out a way to not duplicate this 3 times
+#[cfg(any(feature = "stm32g431", feature = "stm32g441"))]
 opamps! {
     Opamp1 => opamp1: {
         vinm0: crate::gpio::gpioa::PA3<crate::gpio::Analog>,
@@ -908,6 +909,63 @@ opamps! {
             crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp2,
         },
         output: crate::gpio::gpiob::PB1<crate::gpio::Analog>,
+    },
+}
+
+#[cfg(any(feature = "stm32g471", feature = "stm32g491", feature = "stm32g4a1"))]
+opamps! {
+    opamp1: {
+        vinm0: PA3,
+        inverting: {
+            crate::gpio::gpioa::PA3<crate::gpio::Analog>: vinm0,
+            crate::gpio::gpioc::PC5<crate::gpio::Analog>: vinm1,
+        },
+        non_inverting: {
+            crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp0,
+            crate::gpio::gpioa::PA3<crate::gpio::Analog>: vinp1,
+            crate::gpio::gpioa::PA7<crate::gpio::Analog>: vinp2,
+        },
+        output: crate::gpio::gpioa::PA2<crate::gpio::Analog>,
+    },
+    opamp2: {
+        vinm0: PA5,
+        inverting: {
+            crate::gpio::gpioa::PA5<crate::gpio::Analog>: vinm0,
+            crate::gpio::gpioc::PC5<crate::gpio::Analog>: vinm1,
+        },
+        non_inverting: {
+            crate::gpio::gpioa::PA7<crate::gpio::Analog>: vinp0,
+            crate::gpio::gpiob::PB14<crate::gpio::Analog>: vinp1,
+            crate::gpio::gpiob::PB0<crate::gpio::Analog>: vinp2,
+            crate::gpio::gpiod::PD14<crate::gpio::Analog>: vinp3,
+        },
+        output: crate::gpio::gpioa::PA6<crate::gpio::Analog>,
+    },
+    opamp3: {
+        vinm0: PB2,
+        inverting: {
+            crate::gpio::gpiob::PB2<crate::gpio::Analog>: vinm0,
+            crate::gpio::gpiob::PB10<crate::gpio::Analog>: vinm1,
+        },
+        non_inverting: {
+            crate::gpio::gpiob::PB0<crate::gpio::Analog>: vinp0,
+            crate::gpio::gpiob::PB13<crate::gpio::Analog>: vinp1,
+            crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp2,
+        },
+        output: crate::gpio::gpiob::PB1<crate::gpio::Analog>,
+    },
+    opamp6: {
+        vinm0: PA1,
+        inverting: {
+            crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinm0,
+            crate::gpio::gpiob::PB1<crate::gpio::Analog>: vinm1,
+        },
+        non_inverting: {
+            crate::gpio::gpiob::PB12<crate::gpio::Analog>: vinp0,
+            crate::gpio::gpiod::PD9<crate::gpio::Analog>: vinp1,
+            crate::gpio::gpiob::PB13<crate::gpio::Analog>: vinp2,
+        },
+        output: crate::gpio::gpiob::PB11<crate::gpio::Analog>,
     },
 }
 

--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -333,13 +333,13 @@ macro_rules! opamps {
                     #[inline(always)]
                     unsafe fn _disable_output() {
                         (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>]().modify(|_, w|
-                            w.opaintoen().adcchannel())
+                            w.opaintoen().adcchannel());
                     }
 
                     #[inline(always)]
                     unsafe fn _enable_output() {
                         (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>]().modify(|_, w|
-                            w.opaintoen().output_pin())
+                            w.opaintoen().output_pin());
                     }
 
                     #[inline(always)]
@@ -352,7 +352,7 @@ macro_rules! opamps {
                         // the user doesn't want anything changing if they care to set
                         // the lock bit.
                         (*crate::stm32::OPAMP::ptr()).[<$opampreg _tcmr>]().modify(|_, w|
-                            w.lock().set_bit())
+                            w.lock().set_bit());
                     }
                 }
 

--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -914,8 +914,9 @@ opamps! {
 
 #[cfg(any(feature = "stm32g471", feature = "stm32g491", feature = "stm32g4a1"))]
 opamps! {
-    opamp1: {
-        vinm0: PA3,
+    Opamp1 => opamp1: {
+        vinm0: crate::gpio::gpioa::PA3<crate::gpio::Analog>,
+        vinm1: crate::gpio::gpioc::PC5<crate::gpio::Analog>,
         inverting: {
             crate::gpio::gpioa::PA3<crate::gpio::Analog>: vinm0,
             crate::gpio::gpioc::PC5<crate::gpio::Analog>: vinm1,
@@ -927,8 +928,9 @@ opamps! {
         },
         output: crate::gpio::gpioa::PA2<crate::gpio::Analog>,
     },
-    opamp2: {
-        vinm0: PA5,
+    Opamp2 => opamp2: {
+        vinm0: crate::gpio::gpioa::PA5<crate::gpio::Analog>,
+        vinm1: crate::gpio::gpioc::PC5<crate::gpio::Analog>,
         inverting: {
             crate::gpio::gpioa::PA5<crate::gpio::Analog>: vinm0,
             crate::gpio::gpioc::PC5<crate::gpio::Analog>: vinm1,
@@ -941,8 +943,9 @@ opamps! {
         },
         output: crate::gpio::gpioa::PA6<crate::gpio::Analog>,
     },
-    opamp3: {
-        vinm0: PB2,
+    Opamp3 => opamp3: {
+        vinm0: crate::gpio::gpiob::PB2<crate::gpio::Analog>,
+        vinm1: crate::gpio::gpiob::PB10<crate::gpio::Analog>,
         inverting: {
             crate::gpio::gpiob::PB2<crate::gpio::Analog>: vinm0,
             crate::gpio::gpiob::PB10<crate::gpio::Analog>: vinm1,
@@ -954,8 +957,9 @@ opamps! {
         },
         output: crate::gpio::gpiob::PB1<crate::gpio::Analog>,
     },
-    opamp6: {
-        vinm0: PA1,
+    Opamp6 => opamp6: {
+        vinm0: crate::gpio::gpioa::PA1<crate::gpio::Analog>,
+        vinm1: crate::gpio::gpiob::PB1<crate::gpio::Analog>,
         inverting: {
             crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinm0,
             crate::gpio::gpiob::PB1<crate::gpio::Analog>: vinm1,

--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -290,36 +290,36 @@ macro_rules! opamps {
                 pub struct $opamp;
 
                 impl LookupPgaGain for $opamp {
-                    type PgaGainReg = crate::stm32::opamp::[<$opampreg _csr>]::PGA_GAIN_A;
+                    type PgaGainReg = crate::stm32::opamp::[<$opampreg _csr>]::PGA_GAIN;
 
                     fn pga_gain(mode: PgaMode, gain: Gain) -> Self::PgaGainReg {
-                        use crate::stm32::opamp::[<$opampreg _csr>]::PGA_GAIN_A;
+                        use crate::stm32::opamp::[<$opampreg _csr>]::PGA_GAIN;
 
                         match (mode, gain) {
-                            (PgaMode::Pga, Gain::Gain2) => PGA_GAIN_A::Gain2,
-                            (PgaMode::Pga, Gain::Gain4) => PGA_GAIN_A::Gain4,
-                            (PgaMode::Pga, Gain::Gain8) => PGA_GAIN_A::Gain8,
-                            (PgaMode::Pga, Gain::Gain16) => PGA_GAIN_A::Gain16,
-                            (PgaMode::Pga, Gain::Gain32) => PGA_GAIN_A::Gain32,
-                            (PgaMode::Pga, Gain::Gain64) => PGA_GAIN_A::Gain64,
-                            (PgaMode::PgaExternalFilter, Gain::Gain2) => PGA_GAIN_A::Gain2FilteringVinm0,
-                            (PgaMode::PgaExternalFilter, Gain::Gain4) => PGA_GAIN_A::Gain4FilteringVinm0,
-                            (PgaMode::PgaExternalFilter, Gain::Gain8) => PGA_GAIN_A::Gain8FilteringVinm0,
-                            (PgaMode::PgaExternalFilter, Gain::Gain16) => PGA_GAIN_A::Gain16FilteringVinm0,
-                            (PgaMode::PgaExternalFilter, Gain::Gain32) => PGA_GAIN_A::Gain32FilteringVinm0,
-                            (PgaMode::PgaExternalFilter, Gain::Gain64) => PGA_GAIN_A::Gain64FilteringVinm0,
-                            (PgaMode::PgaExternalBias, Gain::Gain2) => PGA_GAIN_A::Gain2InputVinm0,
-                            (PgaMode::PgaExternalBias, Gain::Gain4) => PGA_GAIN_A::Gain4InputVinm0,
-                            (PgaMode::PgaExternalBias, Gain::Gain8) => PGA_GAIN_A::Gain8InputVinm0,
-                            (PgaMode::PgaExternalBias, Gain::Gain16) => PGA_GAIN_A::Gain16InputVinm0,
-                            (PgaMode::PgaExternalBias, Gain::Gain32) => PGA_GAIN_A::Gain32InputVinm0,
-                            (PgaMode::PgaExternalBias, Gain::Gain64) => PGA_GAIN_A::Gain64InputVinm0,
-                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain2) => PGA_GAIN_A::Gain2InputVinm0filteringVinm1,
-                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain4) => PGA_GAIN_A::Gain4InputVinm0filteringVinm1,
-                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain8) => PGA_GAIN_A::Gain8InputVinm0filteringVinm1,
-                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain16) => PGA_GAIN_A::Gain16InputVinm0filteringVinm1,
-                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain32) => PGA_GAIN_A::Gain32InputVinm0filteringVinm1,
-                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain64) => PGA_GAIN_A::Gain64InputVinm0filteringVinm1,
+                            (PgaMode::Pga, Gain::Gain2) => PGA_GAIN::Gain2,
+                            (PgaMode::Pga, Gain::Gain4) => PGA_GAIN::Gain4,
+                            (PgaMode::Pga, Gain::Gain8) => PGA_GAIN::Gain8,
+                            (PgaMode::Pga, Gain::Gain16) => PGA_GAIN::Gain16,
+                            (PgaMode::Pga, Gain::Gain32) => PGA_GAIN::Gain32,
+                            (PgaMode::Pga, Gain::Gain64) => PGA_GAIN::Gain64,
+                            (PgaMode::PgaExternalFilter, Gain::Gain2) => PGA_GAIN::Gain2FilteringVinm0,
+                            (PgaMode::PgaExternalFilter, Gain::Gain4) => PGA_GAIN::Gain4FilteringVinm0,
+                            (PgaMode::PgaExternalFilter, Gain::Gain8) => PGA_GAIN::Gain8FilteringVinm0,
+                            (PgaMode::PgaExternalFilter, Gain::Gain16) => PGA_GAIN::Gain16FilteringVinm0,
+                            (PgaMode::PgaExternalFilter, Gain::Gain32) => PGA_GAIN::Gain32FilteringVinm0,
+                            (PgaMode::PgaExternalFilter, Gain::Gain64) => PGA_GAIN::Gain64FilteringVinm0,
+                            (PgaMode::PgaExternalBias, Gain::Gain2) => PGA_GAIN::Gain2InputVinm0,
+                            (PgaMode::PgaExternalBias, Gain::Gain4) => PGA_GAIN::Gain4InputVinm0,
+                            (PgaMode::PgaExternalBias, Gain::Gain8) => PGA_GAIN::Gain8InputVinm0,
+                            (PgaMode::PgaExternalBias, Gain::Gain16) => PGA_GAIN::Gain16InputVinm0,
+                            (PgaMode::PgaExternalBias, Gain::Gain32) => PGA_GAIN::Gain32InputVinm0,
+                            (PgaMode::PgaExternalBias, Gain::Gain64) => PGA_GAIN::Gain64InputVinm0,
+                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain2) => PGA_GAIN::Gain2InputVinm0filteringVinm1,
+                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain4) => PGA_GAIN::Gain4InputVinm0filteringVinm1,
+                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain8) => PGA_GAIN::Gain8InputVinm0filteringVinm1,
+                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain16) => PGA_GAIN::Gain16InputVinm0filteringVinm1,
+                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain32) => PGA_GAIN::Gain32InputVinm0filteringVinm1,
+                            (PgaMode::PgaExternalBiasAndFilter, Gain::Gain64) => PGA_GAIN::Gain64InputVinm0filteringVinm1,
                         }
                     }
                 }
@@ -327,31 +327,31 @@ macro_rules! opamps {
                 impl $opamp {
                     #[inline(always)]
                     unsafe fn _reset() {
-                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>].reset()
+                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>]().reset()
                     }
 
                     #[inline(always)]
                     unsafe fn _disable_output() {
-                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>].modify(|_, w|
+                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>]().modify(|_, w|
                             w.opaintoen().adcchannel())
                     }
 
                     #[inline(always)]
                     unsafe fn _enable_output() {
-                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>].modify(|_, w|
+                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>]().modify(|_, w|
                             w.opaintoen().output_pin())
                     }
 
                     #[inline(always)]
                     unsafe fn _lock() {
                         // Write the lock bit
-                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>].modify(|_, w|
+                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _csr>]().modify(|_, w|
                             w.lock().set_bit());
                         // Write the lock bit for the corresponding TCMR register.
                         // We don't currently expose TCMR functionality, but presumably
                         // the user doesn't want anything changing if they care to set
                         // the lock bit.
-                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _tcmr>].modify(|_, w|
+                        (*crate::stm32::OPAMP::ptr()).[<$opampreg _tcmr>]().modify(|_, w|
                             w.lock().set_bit())
                     }
                 }
@@ -531,7 +531,7 @@ macro_rules! opamps {
                 ) -> (
                     $(Disabled::<$opamp>,)*
                 ) {
-                    rcc.rb.apb2enr.modify(|_, w| w.syscfgen().set_bit());
+                    rcc.rb.apb2enr().modify(|_, w| w.syscfgen().set_bit());
 
                     (
                         $(Disabled::<$opamp> { opamp: PhantomData },)*
@@ -581,9 +581,9 @@ macro_rules! opamps {
                 ) -> Follower<$opamp, $input, InternalOutput> {
                     let input = input.into();
                     unsafe {
-                        use crate::stm32::opamp::[<$opampreg _csr>]::OPAINTOEN_A;
+                        use crate::stm32::opamp::[<$opampreg _csr>]::OPAINTOEN;
                         (*crate::stm32::OPAMP::ptr())
-                            .[<$opampreg _csr>]
+                            .[<$opampreg _csr>]()
                             .write(|csr_w|
                                 csr_w
                                     .vp_sel()
@@ -591,7 +591,7 @@ macro_rules! opamps {
                                     .vm_sel()
                                     .output()
                                     .opaintoen()
-                                    .variant(OPAINTOEN_A::Adcchannel)
+                                    .variant(OPAINTOEN::Adcchannel)
                                     .opaen()
                                     .enabled()
                             );
@@ -665,16 +665,16 @@ macro_rules! opamps {
                     let non_inverting = non_inverting.into();
                     let inverting = inverting.into();
                     unsafe {
-                        use crate::stm32::opamp::[<$opampreg _csr>]::OPAINTOEN_A;
+                        use crate::stm32::opamp::[<$opampreg _csr>]::OPAINTOEN;
                         (*crate::stm32::OPAMP::ptr())
-                            .[<$opampreg _csr>]
+                            .[<$opampreg _csr>]()
                             .write(|csr_w|
                                 csr_w.vp_sel()
                                     .$non_inverting_mask()
                                     .vm_sel()
                                     .$inverting_mask()
                                     .opaintoen()
-                                    .variant(OPAINTOEN_A::Adcchannel)
+                                    .variant(OPAINTOEN::Adcchannel)
                                     .opaen()
                                     .enabled()
                             );
@@ -725,10 +725,10 @@ macro_rules! opamps {
 
                 /// Configures the opamp for programmable gain operation.
                 unsafe fn write_pga_reg(gain: Gain, mode: PgaMode, output_enable: bool) {
-                    use crate::stm32::opamp::[<$opampreg _csr>]::OPAINTOEN_A;
+                    use crate::stm32::opamp::[<$opampreg _csr>]::OPAINTOEN;
 
                     (*crate::stm32::OPAMP::ptr())
-                        .[<$opampreg _csr>]
+                        .[<$opampreg _csr>]()
                         .write(|csr_w|
                             csr_w.vp_sel()
                                 .$non_inverting_mask()
@@ -738,8 +738,8 @@ macro_rules! opamps {
                                 .variant($opamp::pga_gain(mode, gain))
                                 .opaintoen()
                                 .variant(match output_enable {
-                                    true => OPAINTOEN_A::OutputPin,
-                                    false => OPAINTOEN_A::Adcchannel,
+                                    true => OPAINTOEN::OutputPin,
+                                    false => OPAINTOEN::Adcchannel,
                                 })
                                 .opaen()
                                 .enabled()

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -874,7 +874,7 @@ pins! {
     feature = "stm32g483",
     feature = "stm32g484",
     feature = "stm32g491",
-    feature = "stm32g4a1"
+    feature = "stm32g4a1",
 ))]
 pins! {
     TIM20:

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1259,7 +1259,7 @@ macro_rules! tim_hal {
                             2 => tim.cr1().modify(|_, w| unsafe { w.ckd().bits(1) }),
                             4 => tim.cr1().modify(|_, w| unsafe { w.ckd().bits(2) }),
                             _ => panic!("Should be unreachable, invalid deadtime prescaler"),
-                        }
+                        };
 
                         let bkp = match self.fault_polarity {
                             Polarity::ActiveLow => false,

--- a/src/pwr.rs
+++ b/src/pwr.rs
@@ -103,10 +103,10 @@ pub(crate) fn current_vos() -> VoltageScale {
     // NOTE(unsafe): Read-only access
     let pwr = unsafe { &*PWR::ptr() };
 
-    match pwr.cr1.read().vos().bits() {
+    match pwr.cr1().read().vos().bits() {
         0b00 => unreachable!(),
         0b01 => VoltageScale::Range1 {
-            enable_boost: pwr.cr5.read().r1mode().bit(),
+            enable_boost: pwr.cr5().read().r1mode().bit(),
         },
         0b10 => VoltageScale::Range2,
         0b11 => unreachable!(),
@@ -129,10 +129,10 @@ pub(crate) unsafe fn set_vos(vos: VoltageScale) {
         VoltageScale::Range1 { .. } => 0b01,
         VoltageScale::Range2 => 0b10,
     };
-    pwr.cr1.modify(|_r, w| w.vos().bits(vos));
+    pwr.cr1().modify(|_r, w| w.vos().bits(vos));
 
     // Wait for ready
-    while pwr.sr2.read().vosf().bit() {}
+    while pwr.sr2().read().vosf().bit() {}
 }
 
 /// Set new voltage scale
@@ -143,5 +143,5 @@ pub(crate) unsafe fn set_vos(vos: VoltageScale) {
 pub(crate) unsafe fn set_boost(enable_boost: bool) {
     let pwr = unsafe { &*PWR::ptr() };
     let r1mode = !enable_boost;
-    pwr.cr5.modify(|_r, w| w.r1mode().bit(r1mode));
+    pwr.cr5().modify(|_r, w| w.r1mode().bit(r1mode));
 }

--- a/src/rcc/clockout.rs
+++ b/src/rcc/clockout.rs
@@ -11,12 +11,12 @@ pub struct Lsco {
 impl Lsco {
     pub fn enable(&self) {
         let rcc = unsafe { &(*RCC::ptr()) };
-        rcc.bdcr.modify(|_, w| w.lscoen().set_bit());
+        rcc.bdcr().modify(|_, w| w.lscoen().set_bit());
     }
 
     pub fn disable(&self) {
         let rcc = unsafe { &(*RCC::ptr()) };
-        rcc.bdcr.modify(|_, w| w.lscoen().clear_bit());
+        rcc.bdcr().modify(|_, w| w.lscoen().clear_bit());
     }
 
     pub fn release(self) -> LscoPin {
@@ -41,7 +41,7 @@ impl LSCOExt for LscoPin {
                 false
             }
         };
-        rcc.rb.bdcr.modify(|_, w| w.lscosel().bit(src_select_bit));
+        rcc.rb.bdcr().modify(|_, w| w.lscosel().bit(src_select_bit));
         Lsco {
             pin: self.into_alternate(),
         }
@@ -56,13 +56,13 @@ pub struct Mco<PIN> {
 impl<PIN> Mco<PIN> {
     pub fn enable(&self) {
         let rcc = unsafe { &(*RCC::ptr()) };
-        rcc.cfgr
+        rcc.cfgr()
             .modify(|_, w| unsafe { w.mcosel().bits(self.src_bits) });
     }
 
     pub fn disable(&self) {
         let rcc = unsafe { &(*RCC::ptr()) };
-        rcc.cfgr.modify(|_, w| unsafe { w.mcosel().bits(0) });
+        rcc.cfgr().modify(|_, w| unsafe { w.mcosel().bits(0) });
     }
 
     pub fn release(self) -> PIN {
@@ -89,7 +89,7 @@ macro_rules! mco {
                         Prescaler::Div64 => 0b110,
                         _ => 0b111,
                     };
-                    rcc.rb.cfgr.modify(|r, w| unsafe {
+                    rcc.rb.cfgr().modify(|r, w| unsafe {
                         w.bits((r.bits() & !(0b111 << 28)) | (psc_bits << 28))
                     });
 

--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -89,7 +89,9 @@ bus! {
     feature = "stm32g473",
     feature = "stm32g474",
     feature = "stm32g483",
-    feature = "stm32g484"
+    feature = "stm32g484",
+    feature = "stm32g491",
+    feature = "stm32g4a1",
 ))]
 bus! {
     ADC3 => (AHB2, 14),
@@ -159,6 +161,16 @@ bus! {
 }
 
 #[cfg(any(
+    feature = "stm32g473",
+    feature = "stm32g474",
+    feature = "stm32g483",
+    feature = "stm32g484",
+))]
+bus! {
+    FDCAN3 => (APB1_1, 25),
+}
+
+#[cfg(any(
     feature = "stm32g471",
     feature = "stm32g473",
     feature = "stm32g474",
@@ -167,8 +179,20 @@ bus! {
 ))]
 bus! {
     TIM5 => (APB1_1, 3),
-    UART5 => (APB1_1, 20),
     I2C4 => (APB1_2, 1),
+}
+
+#[cfg(any(
+    feature = "stm32g471",
+    feature = "stm32g473",
+    feature = "stm32g474",
+    feature = "stm32g483",
+    feature = "stm32g484",
+    feature = "stm32g491",
+    feature = "stm32g4a1",
+))]
+bus! {
+    UART5 => (APB1_1, 20),
 }
 
 bus! {
@@ -198,10 +222,11 @@ bus! {
     feature = "stm32g473",
     feature = "stm32g474",
     feature = "stm32g483",
-    feature = "stm32g484"
+    feature = "stm32g484",
+    feature = "stm32g491",
+    feature = "stm32g4a1",
 ))]
 bus! {
-    FDCAN3 => (APB1_1, 25),
     TIM20 => (APB2, 20),
 }
 

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -188,7 +188,7 @@ impl Rcc {
 
         Self::configure_wait_states(&pwr_cfg, sys_freq);
 
-        self.rb.cfgr.modify(|_, w| unsafe {
+        self.rb.cfgr().modify(|_, w| unsafe {
             w.hpre()
                 .bits(ahb_psc_bits)
                 .ppre1()
@@ -199,7 +199,7 @@ impl Rcc {
                 .bits(sw_bits)
         });
 
-        while self.rb.cfgr.read().sws().bits() != sw_bits {}
+        while self.rb.cfgr().read().sws().bits() != sw_bits {}
 
         // From RM:
         // The timer clock frequencies are automatically defined by hardware. There are two cases:
@@ -232,15 +232,15 @@ impl Rcc {
     }
 
     pub fn unlock_rtc(&mut self) {
-        self.rb.apb1enr1.modify(|_, w| w.pwren().set_bit());
+        self.rb.apb1enr1().modify(|_, w| w.pwren().set_bit());
         let pwr = unsafe { &(*PWR::ptr()) };
-        pwr.cr1.modify(|_, w| w.dbp().set_bit());
+        pwr.cr1().modify(|_, w| w.dbp().set_bit());
     }
 
     fn config_pll(&self, pll_cfg: PllConfig) -> PLLClocks {
         // Disable PLL
-        self.rb.cr.modify(|_, w| w.pllon().clear_bit());
-        while self.rb.cr.read().pllrdy().bit_is_set() {}
+        self.rb.cr().modify(|_, w| w.pllon().clear_bit());
+        while self.rb.cr().read().pllrdy().bit_is_set() {}
 
         // Enable the input clock feeding the PLL
         let (pll_input_freq, pll_src_bits) = match pll_cfg.mux {
@@ -275,7 +275,7 @@ impl Rcc {
             .map(|r| ((pll_freq / r.divisor()).Hz(), r.register_setting()));
 
         // Set the M input divider, the N multiplier for the PLL, and the PLL source.
-        self.rb.pllcfgr.modify(|_, w| unsafe {
+        self.rb.pllcfgr().modify(|_, w| unsafe {
             // Set N, M, and source
             let w = w
                 .plln()
@@ -309,8 +309,8 @@ impl Rcc {
         });
 
         // Enable PLL
-        self.rb.cr.modify(|_, w| w.pllon().set_bit());
-        while self.rb.cr.read().pllrdy().bit_is_clear() {}
+        self.rb.cr().modify(|_, w| w.pllon().set_bit());
+        while self.rb.cr().read().pllrdy().bit_is_clear() {}
 
         PLLClocks {
             r: r.map(|r| r.0),
@@ -362,7 +362,7 @@ impl Rcc {
         unsafe {
             // Adjust flash wait states
             let flash = &(*FLASH::ptr());
-            flash.acr.modify(|_, w| w.latency().bits(latency))
+            flash.acr().modify(|_, w| w.latency().bits(latency))
         }
     }
 
@@ -379,11 +379,11 @@ impl Rcc {
         // The sequence to switch from Range11 normal mode to Range1 boost mode is:
         // 1. The system clock must be divided by 2 using the AHB prescaler before switching to a
         // higher system frequency.
-        let half_apb = (self.rb.cfgr.read().hpre().bits() + 1).clamp(0b1000, 0b1111);
+        let half_apb = (self.rb.cfgr().read().hpre().bits() + 1).clamp(0b1000, 0b1111);
         self.rb
-            .cfgr
+            .cfgr()
             .modify(|_r, w| unsafe { w.hpre().bits(half_apb) });
-        while self.rb.cfgr.read().hpre().bits() != half_apb {}
+        while self.rb.cfgr().read().hpre().bits() != half_apb {}
 
         // 2. Clear the R1MODE bit is in the PWR_CR5 register.
         unsafe { pwr::set_boost(true) };
@@ -392,7 +392,7 @@ impl Rcc {
         Self::configure_wait_states(pwr_cfg, sys_freq);
 
         // 4. Configure and switch to new system frequency.
-        self.rb.cfgr.modify(|_, w| unsafe {
+        self.rb.cfgr().modify(|_, w| unsafe {
             w.ppre1()
                 .bits(apb1_psc_bits)
                 .ppre2()
@@ -401,7 +401,7 @@ impl Rcc {
                 .bits(sw_bits)
         });
 
-        while self.rb.cfgr.read().sws().bits() != sw_bits {}
+        while self.rb.cfgr().read().sws().bits() != sw_bits {}
 
         // 5. Wait for at least 1us and then reconfigure the AHB prescaler to get the needed HCLK
         // clock frequency.
@@ -412,41 +412,41 @@ impl Rcc {
         cortex_m::asm::delay(delay_cycles);
 
         self.rb
-            .cfgr
+            .cfgr()
             .modify(|_, w| unsafe { w.hpre().bits(ahb_psc_bits) });
     }
 
     pub(crate) fn enable_hsi(&self) {
-        self.rb.cr.modify(|_, w| w.hsion().set_bit());
-        while self.rb.cr.read().hsirdy().bit_is_clear() {}
+        self.rb.cr().modify(|_, w| w.hsion().set_bit());
+        while self.rb.cr().read().hsirdy().bit_is_clear() {}
     }
 
     pub(crate) fn enable_hse(&self, bypass: bool) {
         self.rb
-            .cr
+            .cr()
             .modify(|_, w| w.hseon().set_bit().hsebyp().bit(bypass));
-        while self.rb.cr.read().hserdy().bit_is_clear() {}
+        while self.rb.cr().read().hserdy().bit_is_clear() {}
     }
 
     pub(crate) fn enable_lse(&self, bypass: bool) {
         self.rb
-            .bdcr
+            .bdcr()
             .modify(|_, w| w.lseon().set_bit().lsebyp().bit(bypass));
-        while self.rb.bdcr.read().lserdy().bit_is_clear() {}
+        while self.rb.bdcr().read().lserdy().bit_is_clear() {}
     }
 
     pub(crate) fn enable_lsi(&self) {
-        self.rb.csr.modify(|_, w| w.lsion().set_bit());
-        while self.rb.csr.read().lsirdy().bit_is_clear() {}
+        self.rb.csr().modify(|_, w| w.lsion().set_bit());
+        while self.rb.csr().read().lsirdy().bit_is_clear() {}
     }
 
     pub fn enable_hsi48(&self) {
-        self.rb.crrcr.modify(|_, w| w.hsi48on().set_bit());
-        while self.rb.crrcr.read().hsi48rdy().bit_is_clear() {}
+        self.rb.crrcr().modify(|_, w| w.hsi48on().set_bit());
+        while self.rb.crrcr().read().hsi48rdy().bit_is_clear() {}
     }
 
     pub fn get_reset_reason(&self) -> ResetReason {
-        let csr = self.rb.csr.read();
+        let csr = self.rb.csr().read();
 
         ResetReason {
             low_power: csr.lpwrstf().bit(),
@@ -460,7 +460,7 @@ impl Rcc {
     }
 
     pub fn clear_reset_reason(&mut self) {
-        self.rb.csr.modify(|_, w| w.rmvf().set_bit());
+        self.rb.csr().modify(|_, w| w.rmvf().set_bit());
     }
 }
 
@@ -531,16 +531,16 @@ pub struct AHB1 {
 impl AHB1 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::AHB1ENR {
-        &rcc.ahb1enr
+        &rcc.ahb1enr()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::AHB1RSTR {
-        &rcc.ahb1rstr
+        &rcc.ahb1rstr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::AHB1SMENR {
-        &rcc.ahb1smenr
+        &rcc.ahb1smenr()
     }
 }
 
@@ -550,16 +550,16 @@ pub struct AHB2 {
 impl AHB2 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::AHB2ENR {
-        &rcc.ahb2enr
+        &rcc.ahb2enr()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::AHB2RSTR {
-        &rcc.ahb2rstr
+        &rcc.ahb2rstr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::AHB2SMENR {
-        &rcc.ahb2smenr
+        &rcc.ahb2smenr()
     }
 }
 
@@ -570,17 +570,17 @@ impl AHB3 {
     #[allow(unused)]
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::AHB3ENR {
-        &rcc.ahb3enr
+        &rcc.ahb3enr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::AHB3RSTR {
-        &rcc.ahb3rstr
+        &rcc.ahb3rstr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::AHB3SMENR {
-        &rcc.ahb3smenr
+        &rcc.ahb3smenr()
     }
 }
 
@@ -590,16 +590,16 @@ pub struct APB1_1 {
 impl APB1_1 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::APB1ENR1 {
-        &rcc.apb1enr1
+        &rcc.apb1enr1()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::APB1RSTR1 {
-        &rcc.apb1rstr1
+        &rcc.apb1rstr1()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::APB1SMENR1 {
-        &rcc.apb1smenr1
+        &rcc.apb1smenr1()
     }
 }
 
@@ -609,16 +609,16 @@ pub struct APB1_2 {
 impl APB1_2 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::APB1ENR2 {
-        &rcc.apb1enr2
+        &rcc.apb1enr2()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::APB1RSTR2 {
-        &rcc.apb1rstr2
+        &rcc.apb1rstr2()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::APB1SMENR2 {
-        &rcc.apb1smenr2
+        &rcc.apb1smenr2()
     }
 }
 
@@ -628,16 +628,16 @@ pub struct APB2 {
 impl APB2 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::APB2ENR {
-        &rcc.apb2enr
+        &rcc.apb2enr()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::APB2RSTR {
-        &rcc.apb2rstr
+        &rcc.apb2rstr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::APB2SMENR {
-        &rcc.apb2smenr
+        &rcc.apb2smenr()
     }
 }
 

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -362,7 +362,7 @@ impl Rcc {
         unsafe {
             // Adjust flash wait states
             let flash = &(*FLASH::ptr());
-            flash.acr().modify(|_, w| w.latency().bits(latency))
+            flash.acr().modify(|_, w| w.latency().bits(latency));
         }
     }
 

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -531,16 +531,16 @@ pub struct AHB1 {
 impl AHB1 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::AHB1ENR {
-        &rcc.ahb1enr()
+        rcc.ahb1enr()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::AHB1RSTR {
-        &rcc.ahb1rstr()
+        rcc.ahb1rstr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::AHB1SMENR {
-        &rcc.ahb1smenr()
+        rcc.ahb1smenr()
     }
 }
 
@@ -550,16 +550,16 @@ pub struct AHB2 {
 impl AHB2 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::AHB2ENR {
-        &rcc.ahb2enr()
+        rcc.ahb2enr()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::AHB2RSTR {
-        &rcc.ahb2rstr()
+        rcc.ahb2rstr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::AHB2SMENR {
-        &rcc.ahb2smenr()
+        rcc.ahb2smenr()
     }
 }
 
@@ -570,17 +570,17 @@ impl AHB3 {
     #[allow(unused)]
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::AHB3ENR {
-        &rcc.ahb3enr()
+        rcc.ahb3enr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::AHB3RSTR {
-        &rcc.ahb3rstr()
+        rcc.ahb3rstr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::AHB3SMENR {
-        &rcc.ahb3smenr()
+        rcc.ahb3smenr()
     }
 }
 
@@ -590,16 +590,16 @@ pub struct APB1_1 {
 impl APB1_1 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::APB1ENR1 {
-        &rcc.apb1enr1()
+        rcc.apb1enr1()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::APB1RSTR1 {
-        &rcc.apb1rstr1()
+        rcc.apb1rstr1()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::APB1SMENR1 {
-        &rcc.apb1smenr1()
+        rcc.apb1smenr1()
     }
 }
 
@@ -609,16 +609,16 @@ pub struct APB1_2 {
 impl APB1_2 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::APB1ENR2 {
-        &rcc.apb1enr2()
+        rcc.apb1enr2()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::APB1RSTR2 {
-        &rcc.apb1rstr2()
+        rcc.apb1rstr2()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::APB1SMENR2 {
-        &rcc.apb1smenr2()
+        rcc.apb1smenr2()
     }
 }
 
@@ -628,16 +628,16 @@ pub struct APB2 {
 impl APB2 {
     #[inline(always)]
     fn enr(rcc: &RccRB) -> &rcc::APB2ENR {
-        &rcc.apb2enr()
+        rcc.apb2enr()
     }
     #[inline(always)]
     fn rstr(rcc: &RccRB) -> &rcc::APB2RSTR {
-        &rcc.apb2rstr()
+        rcc.apb2rstr()
     }
     #[allow(unused)]
     #[inline(always)]
     fn smenr(rcc: &RccRB) -> &rcc::APB2SMENR {
-        &rcc.apb2smenr()
+        rcc.apb2smenr()
     }
 }
 

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -166,25 +166,25 @@ macro_rules! uart_shared {
             /// Starts listening for an interrupt event
             pub fn listen(&mut self) {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.cr1.modify(|_, w| w.rxneie().set_bit());
+                usart.cr1().modify(|_, w| w.rxneie().set_bit());
             }
 
             /// Stop listening for an interrupt event
             pub fn unlisten(&mut self) {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.cr1.modify(|_, w| w.rxneie().clear_bit());
+                usart.cr1().modify(|_, w| w.rxneie().clear_bit());
             }
 
             /// Return true if the rx register is not empty (and can be read)
             pub fn is_rxne(&self) -> bool {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.isr.read().rxne().bit_is_set()
+                usart.isr().read().rxne().bit_is_set()
             }
 
             /// Returns true if the rx fifo threshold has been reached.
             pub fn fifo_threshold_reached(&self) -> bool {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.isr.read().rxft().bit_is_set()
+                usart.isr().read().rxft().bit_is_set()
             }
         }
 
@@ -192,7 +192,7 @@ macro_rules! uart_shared {
             pub fn enable_dma(self) -> Rx<$USARTX, Pin, DMA> {
                 // NOTE(unsafe) critical section prevents races
                 cortex_m::interrupt::free(|_| unsafe {
-                    let cr3 = &(*$USARTX::ptr()).cr3;
+                    let cr3 = &(*$USARTX::ptr()).cr3();
                     cr3.modify(|_, w| w.dmar().set_bit());
                 });
 
@@ -208,7 +208,7 @@ macro_rules! uart_shared {
             pub fn disable_dma(self) -> Rx<$USARTX, Pin, NoDMA> {
                 // NOTE(unsafe) critical section prevents races
                 interrupt::free(|_| unsafe {
-                    let cr3 = &(*$USARTX::ptr()).cr3;
+                    let cr3 = &(*$USARTX::ptr()).cr3();
                     cr3.modify(|_, w| w.dmar().clear_bit());
                 });
 
@@ -225,22 +225,22 @@ macro_rules! uart_shared {
 
             fn read(&mut self) -> nb::Result<u8, Error> {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                let isr = usart.isr.read();
+                let isr = usart.isr().read();
                 Err(
                     if isr.pe().bit_is_set() {
-                        usart.icr.write(|w| w.pecf().set_bit());
+                        usart.icr().write(|w| w.pecf().set_bit());
                         nb::Error::Other(Error::Parity)
                     } else if isr.fe().bit_is_set() {
-                        usart.icr.write(|w| w.fecf().set_bit());
+                        usart.icr().write(|w| w.fecf().set_bit());
                         nb::Error::Other(Error::Framing)
                     } else if isr.nf().bit_is_set() {
-                        usart.icr.write(|w| w.ncf().set_bit());
+                        usart.icr().write(|w| w.ncf().set_bit());
                         nb::Error::Other(Error::Noise)
                     } else if isr.ore().bit_is_set() {
-                        usart.icr.write(|w| w.orecf().set_bit());
+                        usart.icr().write(|w| w.orecf().set_bit());
                         nb::Error::Other(Error::Overrun)
                     } else if isr.rxne().bit_is_set() {
-                        return Ok(usart.rdr.read().bits() as u8)
+                        return Ok(usart.rdr().read().bits() as u8)
                     } else {
                         nb::Error::WouldBlock
                     }
@@ -260,25 +260,25 @@ macro_rules! uart_shared {
             /// Starts listening for an interrupt event
             pub fn listen(&mut self) {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.cr1.modify(|_, w| w.txeie().set_bit());
+                usart.cr1().modify(|_, w| w.txeie().set_bit());
             }
 
             /// Stop listening for an interrupt event
             pub fn unlisten(&mut self) {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.cr1.modify(|_, w| w.txeie().clear_bit());
+                usart.cr1().modify(|_, w| w.txeie().clear_bit());
             }
 
             /// Return true if the tx register is empty (and can accept data)
             pub fn is_txe(&self) -> bool {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.isr.read().txe().bit_is_set()
+                usart.isr().read().txe().bit_is_set()
             }
 
             /// Returns true if the tx fifo threshold has been reached.
             pub fn fifo_threshold_reached(&self) -> bool {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.isr.read().txft().bit_is_set()
+                usart.isr().read().txft().bit_is_set()
             }
         }
 
@@ -286,7 +286,7 @@ macro_rules! uart_shared {
             pub fn enable_dma(self) -> Tx<$USARTX, Pin, DMA> {
                 // NOTE(unsafe) critical section prevents races
                 interrupt::free(|_| unsafe {
-                    let cr3 = &(*$USARTX::ptr()).cr3;
+                    let cr3 = &(*$USARTX::ptr()).cr3();
                     cr3.modify(|_, w| w.dmat().set_bit());
                 });
 
@@ -302,7 +302,7 @@ macro_rules! uart_shared {
             pub fn disable_dma(self) -> Tx<$USARTX, Pin, NoDMA> {
                 // NOTE(unsafe) critical section prevents races
                 interrupt::free(|_| unsafe {
-                    let cr3 = &(*$USARTX::ptr()).cr3;
+                    let cr3 = &(*$USARTX::ptr()).cr3();
                     cr3.modify(|_, w| w.dmat().clear_bit());
                 });
 
@@ -319,7 +319,7 @@ macro_rules! uart_shared {
 
             fn flush(&mut self) -> nb::Result<(), Self::Error> {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                if usart.isr.read().tc().bit_is_set() {
+                if usart.isr().read().tc().bit_is_set() {
                     Ok(())
                 } else {
                     Err(nb::Error::WouldBlock)
@@ -328,8 +328,8 @@ macro_rules! uart_shared {
 
             fn write(&mut self, byte: u8) -> nb::Result<(), Self::Error> {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                if usart.isr.read().txe().bit_is_set() {
-                    usart.tdr.write(|w| unsafe { w.bits(byte as u32) });
+                if usart.isr().read().txe().bit_is_set() {
+                    usart.tdr().write(|w| unsafe { w.bits(byte as u32) });
                     Ok(())
                 } else {
                     Err(nb::Error::WouldBlock)
@@ -379,7 +379,7 @@ macro_rules! uart_shared {
             /// changes.
             pub fn release(self) -> ($USARTX, TX, RX) {
                 // Disable the UART as well as its clock.
-                self.tx.usart.cr1.modify(|_, w| w.ue().clear_bit());
+                self.tx.usart.cr1().modify(|_, w| w.ue().clear_bit());
                 unsafe {
                     let rcc_ptr = &(*RCC::ptr());
                     $USARTX::disable(rcc_ptr);
@@ -392,7 +392,7 @@ macro_rules! uart_shared {
             #[inline(always)]
             fn address(&self) -> u32 {
                 // unsafe: only the Tx part accesses the Tx register
-                &unsafe { &*<$USARTX>::ptr() }.tdr as *const _ as u32
+                &unsafe { &*<$USARTX>::ptr() }.tdr() as *const _ as u32
             }
 
             type MemSize = u8;
@@ -404,7 +404,7 @@ macro_rules! uart_shared {
             #[inline(always)]
             fn address(&self) -> u32 {
                 // unsafe: only the Rx part accesses the Rx register
-                &unsafe { &*<$USARTX>::ptr() }.rdr as *const _ as u32
+                &unsafe { &*<$USARTX>::ptr() }.rdr() as *const _ as u32
             }
 
             type MemSize = u8;
@@ -464,21 +464,21 @@ macro_rules! uart_lp {
                     // We need 16x oversampling.
                     return Err(InvalidConfig);
                 }
-                usart.brr.write(|w| unsafe { w.bits(div as u32) });
+                usart.brr().write(|w| unsafe { w.bits(div as u32) });
                 // Reset the UART and disable it (UE=0)
-                usart.cr1.reset();
+                usart.cr1().reset();
                 // Reset other registers to disable advanced USART features
-                usart.cr2.reset();
-                usart.cr3.reset();
+                usart.cr2().reset();
+                usart.cr3().reset();
 
-                usart.cr2.write(|w| unsafe {
+                usart.cr2().write(|w| unsafe {
                     w.stop()
                         .bits(config.stopbits.bits())
                         .swap()
                         .bit(config.swap)
                 });
 
-                usart.cr3.write(|w| unsafe {
+                usart.cr3().write(|w| unsafe {
                     w.txftcfg()
                         .bits(config.tx_fifo_threshold.bits())
                         .rxftcfg()
@@ -490,7 +490,7 @@ macro_rules! uart_lp {
                 });
 
                 // Enable the UART and perform remaining configuration.
-                usart.cr1.write(|w| {
+                usart.cr1().write(|w| {
                     w.ue()
                         .set_bit()
                         .te()
@@ -526,9 +526,9 @@ macro_rules! uart_lp {
             /// Starts listening for an interrupt event
             pub fn listen(&mut self, event: Event) {
                 match event {
-                    Event::Rxne => self.tx.usart.cr1.modify(|_, w| w.rxneie().set_bit()),
-                    Event::Txe => self.tx.usart.cr1.modify(|_, w| w.txeie().set_bit()),
-                    Event::Idle => self.tx.usart.cr1.modify(|_, w| w.idleie().set_bit()),
+                    Event::Rxne => self.tx.usart.cr1().modify(|_, w| w.rxneie().set_bit()),
+                    Event::Txe => self.tx.usart.cr1().modify(|_, w| w.txeie().set_bit()),
+                    Event::Idle => self.tx.usart.cr1().modify(|_, w| w.idleie().set_bit()),
                     _ => {}
                 }
             }
@@ -536,16 +536,16 @@ macro_rules! uart_lp {
             /// Stop listening for an interrupt event
             pub fn unlisten(&mut self, event: Event) {
                 match event {
-                    Event::Rxne => self.tx.usart.cr1.modify(|_, w| w.rxneie().clear_bit()),
-                    Event::Txe => self.tx.usart.cr1.modify(|_, w| w.txeie().clear_bit()),
-                    Event::Idle => self.tx.usart.cr1.modify(|_, w| w.idleie().clear_bit()),
+                    Event::Rxne => self.tx.usart.cr1().modify(|_, w| w.rxneie().clear_bit()),
+                    Event::Txe => self.tx.usart.cr1().modify(|_, w| w.txeie().clear_bit()),
+                    Event::Idle => self.tx.usart.cr1().modify(|_, w| w.idleie().clear_bit()),
                     _ => {}
                 }
             }
 
             /// Check if interrupt event is pending
             pub fn is_pending(&mut self, event: Event) -> bool {
-                (self.tx.usart.isr.read().bits() & event.val()) != 0
+                (self.tx.usart.isr().read().bits() & event.val()) != 0
             }
 
             /// Clear pending interrupt
@@ -554,7 +554,7 @@ macro_rules! uart_lp {
                 let mask: u32 = 0x123BFF;
                 self.tx
                     .usart
-                    .icr
+                    .icr()
                     .write(|w| unsafe { w.bits(event.val() & mask) });
             }
         }
@@ -612,14 +612,14 @@ macro_rules! uart_full {
                     // We need 16x oversampling.
                     return Err(InvalidConfig);
                 }
-                usart.brr.write(|w| unsafe { w.bits(div as u32) });
+                usart.brr().write(|w| unsafe { w.bits(div as u32) });
 
                 // Reset the UART and disable it (UE=0)
-                usart.cr1.reset();
-                usart.cr2.reset();
-                usart.cr3.reset();
+                usart.cr1().reset();
+                usart.cr2().reset();
+                usart.cr3().reset();
 
-                usart.cr2.write(|w| unsafe {
+                usart.cr2().write(|w| unsafe {
                     w.stop()
                         .bits(config.stopbits.bits())
                         .swap()
@@ -627,12 +627,12 @@ macro_rules! uart_full {
                 });
 
                 if let Some(timeout) = config.receiver_timeout {
-                    usart.cr1.write(|w| w.rtoie().set_bit());
-                    usart.cr2.modify(|_, w| w.rtoen().set_bit());
-                    usart.rtor.write(|w| unsafe { w.rto().bits(timeout) });
+                    usart.cr1().write(|w| w.rtoie().set_bit());
+                    usart.cr2().modify(|_, w| w.rtoen().set_bit());
+                    usart.rtor().write(|w| unsafe { w.rto().bits(timeout) });
                 }
 
-                usart.cr3.write(|w| unsafe {
+                usart.cr3().write(|w| unsafe {
                     w.txftcfg()
                         .bits(config.tx_fifo_threshold.bits())
                         .rxftcfg()
@@ -644,7 +644,7 @@ macro_rules! uart_full {
                 });
 
                 // Enable the UART and perform remaining configuration.
-                usart.cr1.modify(|_, w| {
+                usart.cr1().modify(|_, w| {
                     w.ue()
                         .set_bit()
                         .te()
@@ -680,9 +680,9 @@ macro_rules! uart_full {
             /// Starts listening for an interrupt event
             pub fn listen(&mut self, event: Event) {
                 match event {
-                    Event::Rxne => self.tx.usart.cr1.modify(|_, w| w.rxneie().set_bit()),
-                    Event::Txe => self.tx.usart.cr1.modify(|_, w| w.txeie().set_bit()),
-                    Event::Idle => self.tx.usart.cr1.modify(|_, w| w.idleie().set_bit()),
+                    Event::Rxne => self.tx.usart.cr1().modify(|_, w| w.rxneie().set_bit()),
+                    Event::Txe => self.tx.usart.cr1().modify(|_, w| w.txeie().set_bit()),
+                    Event::Idle => self.tx.usart.cr1().modify(|_, w| w.idleie().set_bit()),
                     _ => {}
                 }
             }
@@ -690,16 +690,16 @@ macro_rules! uart_full {
             /// Stop listening for an interrupt event
             pub fn unlisten(&mut self, event: Event) {
                 match event {
-                    Event::Rxne => self.tx.usart.cr1.modify(|_, w| w.rxneie().clear_bit()),
-                    Event::Txe => self.tx.usart.cr1.modify(|_, w| w.txeie().clear_bit()),
-                    Event::Idle => self.tx.usart.cr1.modify(|_, w| w.idleie().clear_bit()),
+                    Event::Rxne => self.tx.usart.cr1().modify(|_, w| w.rxneie().clear_bit()),
+                    Event::Txe => self.tx.usart.cr1().modify(|_, w| w.txeie().clear_bit()),
+                    Event::Idle => self.tx.usart.cr1().modify(|_, w| w.idleie().clear_bit()),
                     _ => {}
                 }
             }
 
             /// Check if interrupt event is pending
             pub fn is_pending(&mut self, event: Event) -> bool {
-                (self.tx.usart.isr.read().bits() & event.val()) != 0
+                (self.tx.usart.isr().read().bits() & event.val()) != 0
             }
 
             /// Clear pending interrupt
@@ -708,7 +708,7 @@ macro_rules! uart_full {
                 let mask: u32 = 0x123BFF;
                 self.tx
                     .usart
-                    .icr
+                    .icr()
                     .write(|w| unsafe { w.bits(event.val() & mask) });
             }
         }
@@ -718,13 +718,13 @@ macro_rules! uart_full {
             /// Returns the current state of the ISR RTOF bit
             pub fn timeout_lapsed(&self) -> bool {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.isr.read().rtof().bit_is_set()
+                usart.isr().read().rtof().bit_is_set()
             }
 
             /// Clear pending receiver timeout interrupt
             pub fn clear_timeout(&mut self) {
                 let usart = unsafe { &(*$USARTX::ptr()) };
-                usart.icr.write(|w| w.rtocf().set_bit());
+                usart.icr().write(|w| w.rtocf().set_bit());
             }
         }
     };

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -529,8 +529,8 @@ macro_rules! uart_lp {
                     Event::Rxne => self.tx.usart.cr1().modify(|_, w| w.rxneie().set_bit()),
                     Event::Txe => self.tx.usart.cr1().modify(|_, w| w.txeie().set_bit()),
                     Event::Idle => self.tx.usart.cr1().modify(|_, w| w.idleie().set_bit()),
-                    _ => {}
-                }
+                    _ => unimplemented!(),
+                };
             }
 
             /// Stop listening for an interrupt event
@@ -539,8 +539,8 @@ macro_rules! uart_lp {
                     Event::Rxne => self.tx.usart.cr1().modify(|_, w| w.rxneie().clear_bit()),
                     Event::Txe => self.tx.usart.cr1().modify(|_, w| w.txeie().clear_bit()),
                     Event::Idle => self.tx.usart.cr1().modify(|_, w| w.idleie().clear_bit()),
-                    _ => {}
-                }
+                    _ => unimplemented!(),
+                };
             }
 
             /// Check if interrupt event is pending
@@ -683,8 +683,8 @@ macro_rules! uart_full {
                     Event::Rxne => self.tx.usart.cr1().modify(|_, w| w.rxneie().set_bit()),
                     Event::Txe => self.tx.usart.cr1().modify(|_, w| w.txeie().set_bit()),
                     Event::Idle => self.tx.usart.cr1().modify(|_, w| w.idleie().set_bit()),
-                    _ => {}
-                }
+                    _ => unimplemented!(),
+                };
             }
 
             /// Stop listening for an interrupt event
@@ -693,8 +693,8 @@ macro_rules! uart_full {
                     Event::Rxne => self.tx.usart.cr1().modify(|_, w| w.rxneie().clear_bit()),
                     Event::Txe => self.tx.usart.cr1().modify(|_, w| w.txeie().clear_bit()),
                     Event::Idle => self.tx.usart.cr1().modify(|_, w| w.idleie().clear_bit()),
-                    _ => {}
-                }
+                    _ => unimplemented!(),
+                };
             }
 
             /// Check if interrupt event is pending

--- a/src/syscfg.rs
+++ b/src/syscfg.rs
@@ -15,7 +15,7 @@ impl SysCfgExt for SYSCFG {
             let rcc = &(*RCC::ptr());
 
             // Enable clock.
-            bb::set(&rcc.apb2enr, 0);
+            bb::set(&rcc.apb2enr(), 0);
 
             // Stall the pipeline to work around erratum 2.1.13 (DM00037591)
             cortex_m::asm::dsb();


### PR DESCRIPTION
#96 requires updates to the pac. However the new pac changes register blocks member fields to access methods.

Almost all this PR does is adding paranthesis to things like
```diff
- dac.dac_cr.modify(|_, w| w.$en().clear_bit());
+ dac.dac_cr().modify(|_, w| w.$en().clear_bit());
```

This PR currently uses stm32g4 from the nightly repo, I assume at some point a new version of the pac is released. We can then merge this PR(after updating it to depend on that released pac).

I will use this as a base when working on #96 for now..

**Edit:**
Now using [stm32g4-staging](https://crates.io/crates/stm32g4-staging)