### PR TITLE
spi: add support for TX DMA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.7.7"
 features = ["critical-section-single-core"]
 
 [dependencies.fdcan]
-version = "0.1.2"
+version = "0.2.0"
 features = ["fdcan_g0_g4_l5"]
 
 [dependencies.cast]


### PR DESCRIPTION
Allow to use the SPI TX with the DMA stream

Quick example:

```
let streams = dp.DMA1.split(&rcc);
let config = DmaConfig::default()
	.transfer_complete_interrupt(false)
	.circular_buffer(true)
	.memory_increment(true);
let mut buf : [u8; BUFFER_SIZE] = [0; BUFFER_SIZE];
[...]
let led_buf = cortex_m::singleton!(: [u8; BUFFER_SIZE] = buf).unwrap();
let mut transfer_led = streams.0.into_memory_to_peripheral_transfer(
	spi.enable_tx_dma(),
	&mut led_buf[..],
	config,
);
```