### PR TITLE
Allow log imports to go unused for examples

### DIFF
--- a/examples/utils/logger.rs
+++ b/examples/utils/logger.rs
@@ -1,9 +1,11 @@
 #![allow(unsafe_code)]
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "log-rtt", feature = "defmt"))] {
+        #[allow(unused_imports)]
         pub use defmt::{info, trace, warn, debug, error};
 
     } else {
+        #[allow(unused_imports)]
         pub use log::{info, trace, warn, debug, error};
     }
 }

--- a/examples/utils/logger.rs
+++ b/examples/utils/logger.rs
@@ -58,7 +58,9 @@ cfg_if::cfg_if! {
     else if #[cfg(all(feature = "log-rtt"/*, feature = "defmt"*/))] {
         use defmt_rtt as _; // global logger
         use panic_probe as _;
+        #[allow(unused_imports)]
         pub use defmt::Logger;
+        #[allow(unused_imports)]
         pub use defmt::println;
 
         #[allow(dead_code)]


### PR DESCRIPTION
Currently building blinky on main will fail to build because of `#![deny(warnings)]` causing unused imports to error.

This PR fixes that by allowing the log imports to go unused. Works for both `defmt` and `log`.