### PR TITLE
clockout: fix lsco logic

### DIFF
--- a/src/rcc/clockout.rs
+++ b/src/rcc/clockout.rs
@@ -30,6 +30,7 @@ pub trait LSCOExt {
 
 impl LSCOExt for LscoPin {
     fn lsco(self, src: LSCOSrc, rcc: &mut Rcc) -> Lsco {
+        rcc.unlock_rtc();
         let src_select_bit = match src {
             LSCOSrc::LSE => {
                 rcc.enable_lse(false);
@@ -40,7 +41,6 @@ impl LSCOExt for LscoPin {
                 false
             }
         };
-        rcc.unlock_rtc();
         rcc.rb.bdcr.modify(|_, w| w.lscosel().bit(src_select_bit));
         Lsco {
             pin: self.into_alternate(),


### PR DESCRIPTION
To be able to properly enable the LSE, the power domain needs to be up first