### PR TITLE
Add internal DAC outputs to available opamp inputs.

### DIFF
--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -96,6 +96,18 @@ pub enum NonInvertingGain {
     Gain64 = 5,
 }
 
+/// Internal output of DAC 3 channel 1.
+pub struct Dac3Out1;
+
+/// Internal output of DAC 3 channel 2.
+pub struct Dac3Out2;
+
+/// Internal output of DAC 4 channel 1.
+pub struct Dac4Out1;
+
+/// Internal output of DAC 4 channel 2.
+pub struct Dac4Out2;
+
 macro_rules! opamps {
     {
         $(
@@ -557,6 +569,7 @@ opamps! {
             crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp0,
             crate::gpio::gpioa::PA3<crate::gpio::Analog>: vinp1,
             crate::gpio::gpioa::PA7<crate::gpio::Analog>: vinp2,
+            crate::opamp::Dac3Out1: dac3_ch1,
         },
         output: crate::gpio::gpioa::PA2<crate::gpio::Analog>,
     },
@@ -584,6 +597,7 @@ opamps! {
             crate::gpio::gpiob::PB0<crate::gpio::Analog>: vinp0,
             crate::gpio::gpiob::PB13<crate::gpio::Analog>: vinp1,
             crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp2,
+            crate::opamp::Dac3Out2: dac3_ch2,
         },
         output: crate::gpio::gpiob::PB1<crate::gpio::Analog>,
     },
@@ -606,6 +620,7 @@ opamps! {
             crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp0,
             crate::gpio::gpioa::PA3<crate::gpio::Analog>: vinp1,
             crate::gpio::gpioa::PA7<crate::gpio::Analog>: vinp2,
+            crate::opamp::Dac3Out1: dac3_ch1,
         },
         output: crate::gpio::gpioa::PA2<crate::gpio::Analog>,
     },
@@ -633,6 +648,7 @@ opamps! {
             crate::gpio::gpiob::PB0<crate::gpio::Analog>: vinp0,
             crate::gpio::gpiob::PB13<crate::gpio::Analog>: vinp1,
             crate::gpio::gpioa::PA1<crate::gpio::Analog>: vinp2,
+            crate::opamp::Dac3Out2: dac3_ch2,
         },
         output: crate::gpio::gpiob::PB1<crate::gpio::Analog>,
     },
@@ -646,6 +662,7 @@ opamps! {
             crate::gpio::gpiob::PB13<crate::gpio::Analog>: vinp0,
             crate::gpio::gpiod::PD11<crate::gpio::Analog>: vinp1,
             crate::gpio::gpiob::PB11<crate::gpio::Analog>: vinp2,
+            crate::opamp::Dac4Out1: dac4_ch1,
         },
         output: crate::gpio::gpiob::PB12<crate::gpio::Analog>,
     },
@@ -659,6 +676,7 @@ opamps! {
             crate::gpio::gpiob::PB14<crate::gpio::Analog>: vinp0,
             crate::gpio::gpiod::PD12<crate::gpio::Analog>: vinp1,
             crate::gpio::gpioc::PC3<crate::gpio::Analog>: vinp2,
+            crate::opamp::Dac4Out2: dac4_ch2,
         },
         output: crate::gpio::gpioa::PA8<crate::gpio::Analog>,
     },
@@ -672,6 +690,7 @@ opamps! {
             crate::gpio::gpiob::PB12<crate::gpio::Analog>: vinp0,
             crate::gpio::gpiod::PD9<crate::gpio::Analog>: vinp1,
             crate::gpio::gpiob::PB13<crate::gpio::Analog>: vinp2,
+            crate::opamp::Dac3Out1: dac3_ch1,
         },
         output: crate::gpio::gpiob::PB11<crate::gpio::Analog>,
     },


### PR DESCRIPTION
This is done by adding internal structs for the DAC outputs and passing these into the constructor functions instead of an input pin, e.g. `opamp1.follower(Dac3Out1, Some(gpioa.pa2.into_analog()));`

I've tested that this works at least with opamps 1, 3, 4, and 5 in follower mode on an STM32G473.  Can't verify everything of course but I don't see anything obvious that would break elsewhere, and it at least builds for other devices.

After writing this I now see related work in https://github.com/stm32-rs/stm32g4xx-hal/pull/113.  If I'm reading right, I think this change is completely orthogonal and should merge with that one pretty cleanly.