### PR TITLE
Corrected alternate function number for PC13 when configured as TIM8 CH4N

### DIFF
--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -852,7 +852,7 @@ pins! {
             PC12<Alternate<AF4>>
         ]
         CH4N: [
-            PC13<Alternate<AF4>>,
+            PC13<Alternate<AF6>>,
             PD0<Alternate<AF6>>
         ]
         BRK: [


### PR DESCRIPTION
See page 75: https://www.st.com/resource/en/datasheet/stm32g474re.pdf

Tested on a custom board.