### PR TITLE
Fix outstanding clippy warnings

### DIFF
--- a/examples/utils/logger.rs
+++ b/examples/utils/logger.rs
@@ -33,7 +33,7 @@ cfg_if::cfg_if! {
                     InterruptSync::new(
                         // We must not use Peripherals::steal() here to get an ITM instance, as the
                         // code might expect to be able to call Peripherals::take() later on.
-                        ItmDest::new(core::mem::transmute(()))
+                        ItmDest::new(core::mem::transmute::<(), stm32g4xx_hal::stm32::ITM>(()))
                     )
                 },
             };

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -85,7 +85,7 @@ impl Temperature {
     /// ## Arguments
     /// * `sample`: ADC sample taken on the [`Temperature`] channel.
     /// * `vdda`: Analog reference voltage (vref+) when the temperature
-    /// sample was taken, in volts.
+    ///     sample was taken, in volts.
     /// * `resolution`: Configured ADC resolution.
     #[inline(always)]
     pub fn temperature_to_degrees_centigrade(
@@ -110,7 +110,7 @@ impl Temperature {
     /// ## Arguments
     /// * `sample`: ADC sample taken on the [`Temperature`] channel.
     /// * `vdda`: Analog reference voltage (vref+) when the temperature
-    /// sample was taken, in millivolts.
+    ///     sample was taken, in millivolts.
     /// * `resolution`: Configured ADC resolution.
     #[inline(always)]
     pub fn temperature_to_degrees_centigrade_coarse(
@@ -1901,7 +1901,7 @@ macro_rules! adc {
                 /// * `channel` - channel to configure
                 /// * `sequence` - where in the sequence to sample the channel. Also called rank in some STM docs/code
                 /// * `sample_time` - how long to sample for. See datasheet and ref manual to work out how long you need\
-                /// to sample for at a given ADC clock frequency
+                ///     to sample for at a given ADC clock frequency
                 pub fn configure_channel<CHANNEL>(&mut self, _channel: &CHANNEL, sequence: config::Sequence, sample_time: config::SampleTime)
                 where
                     CHANNEL: Channel<stm32::$adc_type, ID=u8>
@@ -2122,6 +2122,7 @@ macro_rules! adc {
                 /// Enables the ADC clock, resets the peripheral (optionally), runs calibration and applies the supplied config
                 /// # Arguments
                 /// * `reset` - should a reset be performed. This is provided because on some devices multiple ADCs share the same common reset
+                ///
                 /// TODO: fix needing SYST
                 #[inline(always)]
                 fn claim(self, cs: ClockSource, rcc: &Rcc, delay: &mut impl DelayUs<u8>, reset: bool) -> Adc<stm32::$adc_type, Disabled> {
@@ -2407,7 +2408,7 @@ macro_rules! adc {
                 /// * `channel` - channel to configure
                 /// * `sequence` - where in the sequence to sample the channel. Also called rank in some STM docs/code
                 /// * `sample_time` - how long to sample for. See datasheet and ref manual to work out how long you need\
-                /// to sample for at a given ADC clock frequency
+                ///     to sample for at a given ADC clock frequency
                 #[inline(always)]
                 pub fn configure_channel<CHANNEL>(&mut self, channel: &CHANNEL, sequence: config::Sequence, sample_time: config::SampleTime)
                 where

--- a/src/can.rs
+++ b/src/can.rs
@@ -141,7 +141,7 @@ mod fdcan1 {
     feature = "stm32g483",
     feature = "stm32g484",
     feature = "stm32g491",
-    feature = "stm32g4A1",
+    feature = "stm32g4a1",
 ))]
 mod fdcan2 {
     use super::sealed;

--- a/src/dma/stream.rs
+++ b/src/dma/stream.rs
@@ -523,7 +523,7 @@ macro_rules! dma_stream {
     feature = "stm32g483",
     feature = "stm32g484",
     feature = "stm32g491",
-    feature = "stm32g49a",
+    feature = "stm32g4a1",
 ))]
 dma_stream!(
     // Note: the field names start from one, unlike the RM where they start from

--- a/src/dma/transfer.rs
+++ b/src/dma/transfer.rs
@@ -707,7 +707,7 @@ transfer_constructor!(
     feature = "stm32g483",
     feature = "stm32g484",
     feature = "stm32g491",
-    feature = "stm32g49a",
+    feature = "stm32g4a1",
 ))]
 transfer_constructor!(
     (DMA1, Stream6),

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -181,7 +181,7 @@ use crate::stm32::RCC;
     feature = "stm32g483",
     feature = "stm32g484",
     feature = "stm32g491",
-    feature = "stm32g4A1"
+    feature = "stm32g4a1"
 ))]
 use crate::stm32::TIM20;
 #[cfg(any(
@@ -874,7 +874,7 @@ pins! {
     feature = "stm32g483",
     feature = "stm32g484",
     feature = "stm32g491",
-    feature = "stm32g4A1"
+    feature = "stm32g4a1"
 ))]
 pins! {
     TIM20:
@@ -1753,7 +1753,7 @@ tim_pin_hal! {
     feature = "stm32g483",
     feature = "stm32g484",
     feature = "stm32g491",
-    feature = "stm32g4A1"
+    feature = "stm32g4a1"
 ))]
 tim_pin_hal! {
     TIM20: (C1, cc1e, cc1p, ccmr1_output, oc1pe, oc1m, ccr1, u16, cc1ne, cc1np),

--- a/src/rcc/enable.rs
+++ b/src/rcc/enable.rs
@@ -152,7 +152,7 @@ bus! {
     feature = "stm32g483",
     feature = "stm32g484",
     feature = "stm32g491",
-    feature = "stm32g4A1"
+    feature = "stm32g4a1"
 ))]
 bus! {
     FDCAN2 => (APB1_1, 25),


### PR DESCRIPTION
- Fix feature names for chip variant `stm32g4A1` -> `stm32g4a1` and some typos of `stm32g49a`.
- Fix comment indentation in comments
- Fix missing type in `mem::transmute` use