### PR TITLE
Add embedded-hal 1.0 trait support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,8 @@ cortex-m-log = { version = "0.7", features = ["log-integration"] }
 cfg-if = "0.1.10"
 mpu6050 = "0.1.4"
 bme680 = "0.6.0"
+sh1106 = { git = "https://github.com/techmccat/sh1106.git", branch = "hal-1", version = "0.5.0" }
+embedded-graphics = "0.8.0"
 embedded-sdmmc = "0.3.0"
 
 #TODO: Separate feature sets

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,13 +37,13 @@ default-features = false
 features = ["const-fn"]
 version = "0.2.5"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.4"
-
-[dependencies.embedded-hal-one]
-version = "1.0.0"
+[dependencies.embedded-hal-old]
 package = "embedded-hal"
+features = ["unproven"]
+version = "0.2.7"
+
+[dependencies.embedded-hal]
+version = "1.0.0"
 
 [dependencies.embedded-dma]
 version = "0.1.2"
@@ -95,7 +95,7 @@ stm32g4a1 = ["stm32g4/stm32g4a1"]
 log-itm = ["cortex-m-log/itm"]
 log-rtt = []
 log-semihost = ["cortex-m-log/semihosting"]
-defmt-logging = ["defmt", "nb/defmt-0-3", "embedded-hal-one/defmt-03", "embedded-io/defmt-03"]
+defmt-logging = ["defmt", "nb/defmt-0-3", "embedded-hal/defmt-03", "embedded-io/defmt-03"]
 
 [profile.dev]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,10 @@ version = "0.2.5"
 features = ["unproven"]
 version = "0.2.4"
 
+[dependencies.embedded-hal-one]
+version = "1.0.0-rc.3"
+package = "embedded-hal"
+
 [dependencies.embedded-dma]
 version = "0.1.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ features = ["unproven"]
 version = "0.2.4"
 
 [dependencies.embedded-hal-one]
-version = "1.0.0-rc.3"
+version = "1.0.0"
 package = "embedded-hal"
 
 [dependencies.embedded-dma]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,14 @@ repository = "https://github.com/stm32-rs/stm32g4xx-hal"
 version = "0.0.2"
 
 [dependencies]
-nb = "0.1.1"
+nb = "1"
 stm32g4 = "0.15.1"
 paste = "1.0"
 bitflags = "1.2"
 vcell = "0.1"
 static_assertions = "1.1"
 fugit = "0.3.5"
+embedded-io = "0.6"
 
 [dependencies.cortex-m]
 version = "0.7.7"
@@ -94,7 +95,7 @@ stm32g4a1 = ["stm32g4/stm32g4a1"]
 log-itm = ["cortex-m-log/itm"]
 log-rtt = []
 log-semihost = ["cortex-m-log/semihosting"]
-defmt-logging = ["defmt"]
+defmt-logging = ["defmt", "nb/defmt-0-3", "embedded-hal-one/defmt-03", "embedded-io/defmt-03"]
 
 [profile.dev]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,6 @@ cortex-m-log = { version = "0.7", features = ["log-integration"] }
 cfg-if = "0.1.10"
 mpu6050 = "0.1.4"
 bme680 = "0.6.0"
-sh1106 = { git = "https://github.com/techmccat/sh1106.git", branch = "hal-1", version = "0.5.0" }
-embedded-graphics = "0.8.0"
 embedded-sdmmc = "0.3.0"
 
 #TODO: Separate feature sets

--- a/examples/adc-continious-dma.rs
+++ b/examples/adc-continious-dma.rs
@@ -10,8 +10,6 @@ use crate::hal::{
         config::{Continuous, Dma as AdcDma, SampleTime, Sequence},
         AdcClaim, ClockSource, Temperature, Vref,
     },
-    time::ExtU32,
-    timer::Timer,
     delay::DelayFromCountDownTimer,
     dma::{config::DmaConfig, stream::DMAExt, TransferExt},
     gpio::GpioExt,
@@ -19,6 +17,8 @@ use crate::hal::{
     rcc::{Config, RccExt},
     signature::{VrefCal, VDDA_CALIB},
     stm32::Peripherals,
+    time::ExtU32,
+    timer::Timer,
 };
 use stm32g4xx_hal as hal;
 

--- a/examples/adc-continious.rs
+++ b/examples/adc-continious.rs
@@ -6,7 +6,9 @@ use crate::hal::{
         config::{Continuous, Resolution, SampleTime, Sequence},
         AdcClaim, ClockSource, Temperature, Vref,
     },
-    delay::SYSTDelayExt,
+    time::ExtU32,
+    timer::Timer,
+    delay::DelayFromCountDownTimer,
     gpio::GpioExt,
     pwr::PwrExt,
     rcc::{Config, RccExt},
@@ -29,7 +31,7 @@ fn main() -> ! {
     info!("start");
 
     let dp = Peripherals::take().unwrap();
-    let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
+    // let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
 
     info!("rcc");
 
@@ -42,7 +44,10 @@ fn main() -> ! {
     let pa0 = gpioa.pa0.into_analog();
 
     info!("Setup Adc1");
-    let mut delay = cp.SYST.delay(&rcc.clocks);
+    // let mut delay = cp.SYST.delay(&rcc.clocks);
+    let mut delay = DelayFromCountDownTimer::new(
+        Timer::new(dp.TIM6, &rcc.clocks).start_count_down(100u32.millis()),
+    );
     let mut adc = dp
         .ADC1
         .claim(ClockSource::SystemClock, &rcc, &mut delay, true);

--- a/examples/adc-continious.rs
+++ b/examples/adc-continious.rs
@@ -6,14 +6,14 @@ use crate::hal::{
         config::{Continuous, Resolution, SampleTime, Sequence},
         AdcClaim, ClockSource, Temperature, Vref,
     },
-    time::ExtU32,
-    timer::Timer,
     delay::DelayFromCountDownTimer,
     gpio::GpioExt,
     pwr::PwrExt,
     rcc::{Config, RccExt},
     signature::{VrefCal, VDDA_CALIB},
     stm32::Peripherals,
+    time::ExtU32,
+    timer::Timer,
 };
 use stm32g4xx_hal as hal;
 

--- a/examples/adc-one-shot-dma.rs
+++ b/examples/adc-one-shot-dma.rs
@@ -8,7 +8,9 @@ use crate::hal::{
         config::{Continuous, Dma as AdcDma, Resolution, SampleTime, Sequence},
         AdcClaim, ClockSource, Temperature,
     },
-    delay::SYSTDelayExt,
+    time::ExtU32,
+    timer::Timer,
+    delay::DelayFromCountDownTimer,
     dma::{config::DmaConfig, stream::DMAExt, TransferExt},
     gpio::GpioExt,
     pwr::PwrExt,
@@ -17,10 +19,10 @@ use crate::hal::{
 };
 use stm32g4xx_hal as hal;
 
-use log::info;
 
 #[macro_use]
 mod utils;
+use utils::logger::info;
 
 #[entry]
 fn main() -> ! {
@@ -29,7 +31,7 @@ fn main() -> ! {
     info!("start");
 
     let dp = Peripherals::take().unwrap();
-    let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
+    // let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
 
     info!("rcc");
 
@@ -48,7 +50,10 @@ fn main() -> ! {
     let pa0 = gpioa.pa0.into_analog();
 
     info!("Setup Adc1");
-    let mut delay = cp.SYST.delay(&rcc.clocks);
+    // let mut delay = cp.SYST.delay(&rcc.clocks);
+    let mut delay = DelayFromCountDownTimer::new(
+        Timer::new(dp.TIM6, &rcc.clocks).start_count_down(100u32.millis()),
+    );
     let mut adc = dp
         .ADC1
         .claim(ClockSource::SystemClock, &rcc, &mut delay, true);

--- a/examples/adc-one-shot-dma.rs
+++ b/examples/adc-one-shot-dma.rs
@@ -8,17 +8,16 @@ use crate::hal::{
         config::{Continuous, Dma as AdcDma, Resolution, SampleTime, Sequence},
         AdcClaim, ClockSource, Temperature,
     },
-    time::ExtU32,
-    timer::Timer,
     delay::DelayFromCountDownTimer,
     dma::{config::DmaConfig, stream::DMAExt, TransferExt},
     gpio::GpioExt,
     pwr::PwrExt,
     rcc::{Config, RccExt},
     stm32::Peripherals,
+    time::ExtU32,
+    timer::Timer,
 };
 use stm32g4xx_hal as hal;
-
 
 #[macro_use]
 mod utils;

--- a/examples/adc-one-shot.rs
+++ b/examples/adc-one-shot.rs
@@ -3,7 +3,9 @@
 
 use crate::hal::{
     adc::{config::SampleTime, AdcClaim},
-    delay::SYSTDelayExt,
+    time::ExtU32,
+    timer::Timer,
+    delay::DelayFromCountDownTimer,
     pwr::PwrExt,
     rcc::Config,
     stm32::Peripherals,
@@ -13,10 +15,9 @@ use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;
 
-use log::info;
-
 #[macro_use]
 mod utils;
+use utils::logger::info;
 
 #[entry]
 fn main() -> ! {
@@ -25,7 +26,7 @@ fn main() -> ! {
     info!("start");
 
     let dp = Peripherals::take().unwrap();
-    let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
+    // let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
 
     info!("rcc");
 
@@ -34,7 +35,10 @@ fn main() -> ! {
     let mut rcc = rcc.freeze(Config::hsi(), pwr);
 
     info!("Setup Adc1");
-    let mut delay = cp.SYST.delay(&rcc.clocks);
+    // let mut delay = cp.SYST.delay(&rcc.clocks);
+    let mut delay = DelayFromCountDownTimer::new(
+        Timer::new(dp.TIM6, &rcc.clocks).start_count_down(100u32.millis()),
+    );
     let mut adc = dp.ADC2.claim_and_configure(
         stm32g4xx_hal::adc::ClockSource::SystemClock,
         &rcc,

--- a/examples/adc-one-shot.rs
+++ b/examples/adc-one-shot.rs
@@ -3,12 +3,12 @@
 
 use crate::hal::{
     adc::{config::SampleTime, AdcClaim},
-    time::ExtU32,
-    timer::Timer,
     delay::DelayFromCountDownTimer,
     pwr::PwrExt,
     rcc::Config,
     stm32::Peripherals,
+    time::ExtU32,
+    timer::Timer,
 };
 use hal::prelude::*;
 use stm32g4xx_hal as hal;

--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -11,7 +11,7 @@ use hal::stm32;
 use hal::time::ExtU32;
 use hal::timer::Timer;
 use stm32g4xx_hal as hal;
-use embedded_hal_one::delay::DelayNs;
+use embedded_hal::delay::DelayNs;
 
 use cortex_m_rt::entry;
 use utils::logger::info;
@@ -48,6 +48,6 @@ fn main() -> ! {
         info!("Toggle");
         led.toggle().unwrap();
         info!("TIM2 delay");
-        DelayNs::delay_ms(&mut delay_tim2, 1000);
+        delay_tim2.delay_ms(1000);
     }
 }

--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -11,6 +11,7 @@ use hal::stm32;
 use hal::time::ExtU32;
 use hal::timer::Timer;
 use stm32g4xx_hal as hal;
+use embedded_hal_one::delay::DelayNs;
 
 use cortex_m_rt::entry;
 use utils::logger::info;
@@ -47,6 +48,6 @@ fn main() -> ! {
         info!("Toggle");
         led.toggle().unwrap();
         info!("TIM2 delay");
-        delay_tim2.delay_ms(1000_u16);
+        DelayNs::delay_ms(&mut delay_tim2, 1000);
     }
 }

--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -3,6 +3,7 @@
 #![no_main]
 #![no_std]
 
+use embedded_hal::delay::DelayNs;
 use hal::delay::DelayFromCountDownTimer;
 use hal::prelude::*;
 use hal::pwr::PwrExt;
@@ -11,7 +12,6 @@ use hal::stm32;
 use hal::time::ExtU32;
 use hal::timer::Timer;
 use stm32g4xx_hal as hal;
-use embedded_hal::delay::DelayNs;
 
 use cortex_m_rt::entry;
 use utils::logger::info;

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -14,7 +14,7 @@ use core::cell::RefCell;
 use core::sync::atomic::{AtomicBool, Ordering};
 use cortex_m::{asm::wfi, interrupt::Mutex};
 use cortex_m_rt::entry;
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal::digital::OutputPin;
 
 type ButtonPin = gpioc::PC13<Input<PullDown>>;
 

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -22,10 +22,9 @@ use core::num::{NonZeroU16, NonZeroU8};
 
 use cortex_m_rt::entry;
 
-use log::info;
-
 #[macro_use]
 mod utils;
+use utils::logger::info;
 
 #[entry]
 fn main() -> ! {
@@ -116,7 +115,7 @@ fn main() -> ! {
         bit_rate_switching: false,
         marker: None,
     };
-    info!("Initial Header: {:#X?}", &header);
+    info!("Initial Header: {:#?}", &header);
 
     info!("Transmit initial message");
     block!(can.transmit(header, &buffer)).unwrap();

--- a/examples/comp_w_dac.rs
+++ b/examples/comp_w_dac.rs
@@ -18,20 +18,25 @@ fn main() -> ! {
 #[cfg(feature = "stm32g474")]
 #[entry]
 fn main() -> ! {
-    use embedded_hal::Direction;
+    use embedded_hal_old::Direction;
+    use stm32g4xx_hal as hal;
     use hal::comparator::{self, ComparatorExt, ComparatorSplit};
     use hal::dac::{Dac1IntSig1, DacExt, DacOut};
-    use hal::delay::SYSTDelayExt;
+    use hal::delay::DelayFromCountDownTimer;
+    use hal::time::ExtU32;
+    use hal::timer::Timer;
     use hal::gpio::GpioExt;
     use hal::rcc::RccExt;
     use hal::stm32;
-    use stm32g4xx_hal as hal;
 
     let dp = stm32::Peripherals::take().expect("cannot take peripherals");
-    let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
+    // let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
 
     let mut rcc = dp.RCC.constrain();
-    let mut delay = cp.SYST.delay(&rcc.clocks);
+    // let mut delay = cp.SYST.delay(&rcc.clocks);
+    let mut delay = DelayFromCountDownTimer::new(
+        Timer::new(dp.TIM6, &rcc.clocks).start_count_down(100u32.millis()),
+    );
 
     let gpioa = dp.GPIOA.split(&mut rcc);
 

--- a/examples/comp_w_dac.rs
+++ b/examples/comp_w_dac.rs
@@ -19,15 +19,15 @@ fn main() -> ! {
 #[entry]
 fn main() -> ! {
     use embedded_hal_old::Direction;
-    use stm32g4xx_hal as hal;
     use hal::comparator::{self, ComparatorExt, ComparatorSplit};
     use hal::dac::{Dac1IntSig1, DacExt, DacOut};
     use hal::delay::DelayFromCountDownTimer;
-    use hal::time::ExtU32;
-    use hal::timer::Timer;
     use hal::gpio::GpioExt;
     use hal::rcc::RccExt;
     use hal::stm32;
+    use hal::time::ExtU32;
+    use hal::timer::Timer;
+    use stm32g4xx_hal as hal;
 
     let dp = stm32::Peripherals::take().expect("cannot take peripherals");
     // let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -10,11 +10,11 @@
 
 use embedded_hal_old::Direction;
 use hal::dac::{DacExt, DacOut, GeneratorConfig};
+use hal::delay::DelayFromCountDownTimer;
 use hal::gpio::GpioExt;
 use hal::rcc::RccExt;
 use hal::time::ExtU32;
 use hal::timer::Timer;
-use hal::delay::DelayFromCountDownTimer;
 use stm32g4xx_hal as hal;
 mod utils;
 extern crate cortex_m_rt as rt;

--- a/examples/i2c-bme680.rs
+++ b/examples/i2c-bme680.rs
@@ -5,7 +5,7 @@
 
 use bme680::*;
 use core::time::Duration;
-use embedded_hal::blocking::delay::DelayMs;
+use embedded_hal::delay::DelayNs;
 use hal::delay::DelayFromCountDownTimer;
 use hal::i2c::Config;
 use hal::prelude::*;
@@ -15,10 +15,10 @@ use hal::timer::Timer;
 use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;
-use log::info;
 
 #[macro_use]
 mod utils;
+use utils::logger::info;
 
 #[entry]
 fn main() -> ! {

--- a/examples/i2c-mpu6050.rs
+++ b/examples/i2c-mpu6050.rs
@@ -10,11 +10,11 @@ use hal::time::{ExtU32, RateExtU32};
 use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;
-use log::info;
 use mpu6050::*;
 
 #[macro_use]
 mod utils;
+use utils::logger::info;
 
 #[entry]
 fn main() -> ! {

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -35,7 +35,7 @@ fn main() -> ! {
 
     let buf: [u8; 1] = [0];
     loop {
-        match i2c.write(0x3c, &buf) {
+        match i2c.write(0x3Cu8, &buf) {
             Ok(_) => info!("ok"),
             Err(err) => info!("error: {:?}", err),
         }

--- a/examples/i2c.rs
+++ b/examples/i2c.rs
@@ -10,10 +10,10 @@ use hal::time::RateExtU32;
 use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;
-use log::info;
 
 #[macro_use]
 mod utils;
+use utils::logger::info;
 
 #[entry]
 fn main() -> ! {

--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -3,16 +3,21 @@
 #![no_std]
 #![no_main]
 
-use stm32g4xx_hal::adc::AdcClaim;
-use stm32g4xx_hal::adc::ClockSource;
-use stm32g4xx_hal::gpio::gpioa::*;
-use stm32g4xx_hal::gpio::Analog;
-use stm32g4xx_hal::opamp::opamp1::IntoPga as _;
-use stm32g4xx_hal::opamp::opamp2::IntoPga as _;
-use stm32g4xx_hal::opamp::NonInvertingGain;
-use stm32g4xx_hal::opamp::PgaModeInternal;
-use stm32g4xx_hal::prelude::*;
-use stm32g4xx_hal::pwr::PwrExt;
+use stm32g4xx_hal as hal;
+
+use hal::delay::DelayFromCountDownTimer;
+use hal::timer::Timer;
+use hal::time::ExtU32;
+use hal::adc::AdcClaim;
+use hal::adc::ClockSource;
+use hal::gpio::gpioa::*;
+use hal::gpio::Analog;
+use hal::opamp::opamp1::IntoPga as _;
+use hal::opamp::opamp2::IntoPga as _;
+use hal::opamp::NonInvertingGain;
+use hal::opamp::PgaModeInternal;
+use hal::prelude::*;
+use hal::pwr::PwrExt;
 
 use utils::logger::info;
 
@@ -25,7 +30,7 @@ fn main() -> ! {
 
     // take peripherals
     let dp = stm32g4xx_hal::stm32::Peripherals::take().unwrap();
-    let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
+    // let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
 
     // setup clock and power
     let pwr = dp.PWR.constrain().freeze();
@@ -66,7 +71,10 @@ fn main() -> ! {
         Option::<PA6<Analog>>::None, // Do not route output to any external pin, use internal AD instead
     );
 
-    let mut delay = cp.SYST.delay(&rcc.clocks);
+    // let mut delay = cp.SYST.delay(&rcc.clocks);
+    let mut delay = DelayFromCountDownTimer::new(
+        Timer::new(dp.TIM6, &rcc.clocks).start_count_down(100u32.millis()),
+    );
     let mut adc = dp
         .ADC2
         .claim(ClockSource::SystemClock, &rcc, &mut delay, true);

--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -5,11 +5,9 @@
 
 use stm32g4xx_hal as hal;
 
-use hal::delay::DelayFromCountDownTimer;
-use hal::timer::Timer;
-use hal::time::ExtU32;
 use hal::adc::AdcClaim;
 use hal::adc::ClockSource;
+use hal::delay::DelayFromCountDownTimer;
 use hal::gpio::gpioa::*;
 use hal::gpio::Analog;
 use hal::opamp::opamp1::IntoPga as _;
@@ -18,6 +16,8 @@ use hal::opamp::NonInvertingGain;
 use hal::opamp::PgaModeInternal;
 use hal::prelude::*;
 use hal::pwr::PwrExt;
+use hal::time::ExtU32;
+use hal::timer::Timer;
 
 use utils::logger::info;
 

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -11,6 +11,7 @@ use hal::stm32;
 use hal::time::RateExtU32;
 use stm32g4xx_hal as hal;
 extern crate cortex_m_rt as rt;
+use hal::prelude::SetDutyCycle;
 
 #[macro_use]
 mod utils;
@@ -26,7 +27,7 @@ fn main() -> ! {
 
     let mut pwm = dp.TIM1.pwm(pin, 100.Hz(), &mut rcc);
 
-    pwm.set_duty(pwm.get_max_duty() / 2);
+    let _ = pwm.set_duty_cycle(pwm.max_duty_cycle() / 2);
     pwm.enable();
 
     loop {

--- a/examples/pwm.rs
+++ b/examples/pwm.rs
@@ -27,7 +27,7 @@ fn main() -> ! {
 
     let mut pwm = dp.TIM1.pwm(pin, 100.Hz(), &mut rcc);
 
-    let _ = pwm.set_duty_cycle(pwm.max_duty_cycle() / 2);
+    let _ = pwm.set_duty_cycle_percent(50);
     pwm.enable();
 
     loop {

--- a/examples/spi-dma.rs
+++ b/examples/spi-dma.rs
@@ -28,6 +28,7 @@ use stm32g4xx_hal::dma::TransferExt;
 
 #[macro_use]
 mod utils;
+// use utils::logger::info;
 
 const BUFFER_SIZE: usize = 254;
 
@@ -68,6 +69,6 @@ fn main() -> ! {
             .into_memory_to_peripheral_transfer(spi.enable_tx_dma(), &mut dma_buf[..], config);
     transfer_dma.start(|_spi| {});
     loop {
-        delay_tim2.delay_ms(1000_u16);
+        delay_tim2.delay_ms(1000);
     }
 }

--- a/examples/spi-example.rs
+++ b/examples/spi-example.rs
@@ -5,8 +5,7 @@
 #![no_main]
 #![no_std]
 
-use crate::hal::{
-    block,
+use hal::{
     delay::DelayFromCountDownTimer,
     gpio::gpioa::PA5,
     gpio::gpioa::PA6,
@@ -20,6 +19,7 @@ use crate::hal::{
     stm32::Peripherals,
     time::{ExtU32, RateExtU32},
     timer::Timer,
+    hal_02::spi::FullDuplex,
 };
 
 use cortex_m_rt::entry;
@@ -59,11 +59,11 @@ fn main() -> ! {
         for byte in message.iter() {
             cs.set_low().unwrap();
             spi.send(*byte as u8).unwrap();
-            received_byte = block!(spi.read()).unwrap();
+            received_byte = nb::block!(FullDuplex::read(&mut spi)).unwrap();
             cs.set_high().unwrap();
 
             info!("{}", received_byte as char);
         }
-        delay_tim2.delay_ms(1000_u16);
+        delay_tim2.delay_ms(1000);
     }
 }

--- a/examples/spi-example.rs
+++ b/examples/spi-example.rs
@@ -12,6 +12,7 @@ use hal::{
     gpio::gpioa::PA7,
     gpio::Alternate,
     gpio::AF5,
+    hal_02::spi::FullDuplex,
     prelude::*,
     pwr::PwrExt,
     rcc::Config,
@@ -19,7 +20,6 @@ use hal::{
     stm32::Peripherals,
     time::{ExtU32, RateExtU32},
     timer::Timer,
-    hal_02::spi::FullDuplex,
 };
 
 use cortex_m_rt::entry;

--- a/examples/uart-dma-tx.rs
+++ b/examples/uart-dma-tx.rs
@@ -16,10 +16,10 @@ use hal::{rcc, stm32};
 use stm32g4xx_hal as hal;
 
 use cortex_m_rt::entry;
-use log::info;
 
 #[macro_use]
 mod utils;
+use utils::logger::info;
 
 #[entry]
 fn main() -> ! {

--- a/examples/uart-fifo.rs
+++ b/examples/uart-fifo.rs
@@ -7,17 +7,19 @@ extern crate cortex_m_rt as rt;
 
 use core::fmt::Write;
 
+use stm32g4xx_hal as hal;
 use hal::prelude::*;
 use hal::pwr::PwrExt;
 use hal::serial::*;
 use hal::{rcc, stm32};
-use stm32g4xx_hal as hal;
+// TODO: switch to embedded-hal-nb
+use hal::hal_02::serial::Read;
 
 use cortex_m_rt::entry;
-use log::info;
 
 #[macro_use]
 mod utils;
+use utils::logger::info;
 
 #[entry]
 fn main() -> ! {

--- a/examples/uart-fifo.rs
+++ b/examples/uart-fifo.rs
@@ -7,11 +7,11 @@ extern crate cortex_m_rt as rt;
 
 use core::fmt::Write;
 
-use stm32g4xx_hal as hal;
 use hal::prelude::*;
 use hal::pwr::PwrExt;
 use hal::serial::*;
 use hal::{rcc, stm32};
+use stm32g4xx_hal as hal;
 // TODO: switch to embedded-hal-nb
 use hal::hal_02::serial::Read;
 

--- a/examples/uart.rs
+++ b/examples/uart.rs
@@ -59,7 +59,7 @@ fn main() -> ! {
 
     let mut cnt = 0;
     loop {
-        match block!(embedded_hal::serial::Read::read(&mut usart)) {
+        match block!(embedded_hal_old::serial::Read::read(&mut usart)) {
             Ok(byte) => writeln!(usart, "{}: {}\r", cnt, byte).unwrap(),
             Err(e) => writeln!(usart, "E: {:?}\r", e).unwrap(),
         };

--- a/examples/uart.rs
+++ b/examples/uart.rs
@@ -3,8 +3,7 @@
 #![no_main]
 #![no_std]
 
-use core::fmt::Write;
-
+use embedded_io::{Read, Write};
 use hal::prelude::*;
 use hal::pwr::PwrExt;
 use hal::serial::FullConfig;
@@ -54,10 +53,13 @@ fn main() -> ! {
         .unwrap();
 
     writeln!(usart, "Hello USART3, yay!!\r\n").unwrap();
+    let mut read_buf = [0u8; 8];
+    usart.read_exact(&mut read_buf).unwrap();
+    usart.write_all(&read_buf).unwrap();
 
     let mut cnt = 0;
     loop {
-        match block!(usart.read()) {
+        match block!(embedded_hal::serial::Read::read(&mut usart)) {
             Ok(byte) => writeln!(usart, "{}: {}\r", cnt, byte).unwrap(),
             Err(e) => writeln!(usart, "E: {:?}\r", e).unwrap(),
         };

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -20,10 +20,10 @@ use crate::{
 };
 use core::fmt;
 use core::marker::PhantomData;
-use embedded_hal::{
+use embedded_hal_old::{
     adc::{Channel, OneShot},
-    blocking::delay::DelayUs,
 };
+use embedded_hal::delay::DelayNs;
 
 use self::config::ExternalTrigger12;
 
@@ -168,7 +168,7 @@ macro_rules! adc_op_follower {
 
 /// Contains types related to ADC configuration
 pub mod config {
-    use embedded_hal::adc::Channel;
+    use embedded_hal_old::adc::Channel;
 
     /// The place in the sequence a given channel should be captured
     #[derive(Debug, PartialEq, PartialOrd, Copy, Clone)]
@@ -1381,7 +1381,7 @@ pub trait AdcClaim<TYPE: TriggerType> {
         self,
         cs: ClockSource,
         rcc: &Rcc,
-        delay: &mut impl DelayUs<u8>,
+        delay: &mut impl DelayNs,
         reset: bool,
     ) -> Adc<TYPE, Disabled>;
 
@@ -1391,7 +1391,7 @@ pub trait AdcClaim<TYPE: TriggerType> {
         cs: ClockSource,
         rcc: &Rcc,
         config: config::AdcConfig<TYPE::ExternalTrigger>,
-        delay: &mut impl DelayUs<u8>,
+        delay: &mut impl DelayNs,
         reset: bool,
     ) -> Adc<TYPE, Configured>;
 }
@@ -1583,7 +1583,7 @@ macro_rules! adc {
 
                 /// Powers-up an powered-down Adc
                 #[inline(always)]
-                pub fn power_up(&mut self, delay: &mut impl DelayUs<u8>) {
+                pub fn power_up(&mut self, delay: &mut impl DelayNs) {
                     if self.is_deeppwd_enabled() {
                         self.disable_deeppwd_down();
                     }
@@ -1616,7 +1616,7 @@ macro_rules! adc {
 
                 /// Enables the Voltage Regulator
                 #[inline(always)]
-                pub fn enable_vreg(&mut self, delay: &mut impl DelayUs<u8>) {
+                pub fn enable_vreg(&mut self, delay: &mut impl DelayNs) {
                     self.adc_reg.cr.modify(|_, w| w.advregen().set_bit());
                     while !self.adc_reg.cr.read().advregen().bit_is_set() {}
 
@@ -2125,7 +2125,7 @@ macro_rules! adc {
                 ///
                 /// TODO: fix needing SYST
                 #[inline(always)]
-                fn claim(self, cs: ClockSource, rcc: &Rcc, delay: &mut impl DelayUs<u8>, reset: bool) -> Adc<stm32::$adc_type, Disabled> {
+                fn claim(self, cs: ClockSource, rcc: &Rcc, delay: &mut impl DelayNs, reset: bool) -> Adc<stm32::$adc_type, Disabled> {
                     unsafe {
                         let rcc_ptr = &(*stm32::RCC::ptr());
                         stm32::$adc_type::enable(rcc_ptr);
@@ -2149,7 +2149,7 @@ macro_rules! adc {
 
                 /// claims and configures the Adc
                 #[inline(always)]
-                fn claim_and_configure(self, cs: ClockSource, rcc: &Rcc, config: config::AdcConfig<$trigger_type>, delay: &mut impl DelayUs<u8>, reset :bool) -> Adc<stm32::$adc_type, Configured> {
+                fn claim_and_configure(self, cs: ClockSource, rcc: &Rcc, config: config::AdcConfig<$trigger_type>, delay: &mut impl DelayNs, reset :bool) -> Adc<stm32::$adc_type, Configured> {
                     let mut adc = self.claim(cs, rcc, delay, reset);
                     adc.adc.config = config;
 
@@ -2173,7 +2173,7 @@ macro_rules! adc {
             impl Adc<stm32::$adc_type, PoweredDown> {
                 /// Powers-up an powered-down Adc
                 #[inline(always)]
-                pub fn power_up(mut self, delay: &mut impl DelayUs<u8>) -> Adc<stm32::$adc_type, Disabled> {
+                pub fn power_up(mut self, delay: &mut impl DelayNs) -> Adc<stm32::$adc_type, Disabled> {
                     self.adc.power_up(delay);
 
                     Adc {

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -20,10 +20,8 @@ use crate::{
 };
 use core::fmt;
 use core::marker::PhantomData;
-use embedded_hal_old::{
-    adc::{Channel, OneShot},
-};
 use embedded_hal::delay::DelayNs;
+use embedded_hal_old::adc::{Channel, OneShot};
 
 use self::config::ExternalTrigger12;
 

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1,5 +1,5 @@
 //! Analog to digital converter configuration.
-//! https://github.com/stm32-rs/stm32l4xx-hal/blob/master/src/adc.rs
+//! <https://github.com/stm32-rs/stm32l4xx-hal/blob/master/src/adc.rs>
 
 #![deny(missing_docs)]
 
@@ -310,7 +310,8 @@ pub mod config {
     pub enum ClockMode {
         /// (Asynchronous clock mode), adc_ker_ck. generated at product level (refer to Section 6: Reset and clock control (RCC)
         Asynchronous,
-        /// (Synchronous clock mode). adc_hclk/1 This configuration must be enabled only if the AHB clock prescaler is set to 1 (HPRE[3:0] = 0xxx in RCC_CFGR register) and if the system clock has a 50% duty cycle.
+        /// (Synchronous clock mode). adc_hclk/1
+        /// This configuration must be enabled only if the AHB clock prescaler is set to 1 (HPRE\[3:0\] = 0xxx in RCC_CFGR register) and if the system clock has a 50% duty cycle.
         Synchronous_Div_1,
         /// Synchronous clock mode. adc_hclk/2
         Synchronous_Div_2,
@@ -1166,9 +1167,9 @@ impl<ADC: TriggerType> Conversion<ADC> {
         !self.is_active()
     }
 
-    /// Converts from Conversion<C, E> to Option<C>.
+    /// Converts from `Conversion<C, E>` to `Option<C>`.
     ///
-    /// Converts self into an Option<C>, consuming self, and discarding the adc, if it is stopped.
+    /// Converts self into an `Option<C>`, consuming self, and discarding the adc, if it is stopped.
     #[inline(always)]
     pub fn active(self) -> Option<Adc<ADC, Active>> {
         match self {
@@ -1177,9 +1178,9 @@ impl<ADC: TriggerType> Conversion<ADC> {
         }
     }
 
-    /// Converts from Conversion<C, E> to Option<E>.
+    /// Converts from `Conversion<C, E>` to `Option<E>`.
     ///
-    /// Converts self into an Option<E>, consuming self, and discarding the adc, if it is still active.
+    /// Converts self into an `Option<E>`, consuming self, and discarding the adc, if it is still active.
     #[inline(always)]
     pub fn stopped(self) -> Option<Adc<ADC, Configured>> {
         match self {

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -12,7 +12,7 @@ use crate::gpio::gpioa::{PA4, PA5, PA6};
 use crate::gpio::DefaultMode;
 use crate::rcc::{self, *};
 use crate::stm32::{DAC1, DAC2, DAC3, DAC4, RCC};
-use hal::blocking::delay::DelayUs;
+use embedded_hal::delay::DelayNs;
 
 pub trait DacOut<V> {
     fn set_value(&mut self, val: V);
@@ -230,9 +230,9 @@ macro_rules! dac_helper {
                 ///
                 /// After the calibration operation, the DAC channel is
                 /// disabled.
-                pub fn calibrate_buffer<T>(self, delay: &mut T) -> $CX<MODE_BITS, Disabled>
+                pub fn calibrate_buffer<D>(self, delay: &mut D) -> $CX<MODE_BITS, Disabled>
                 where
-                    T: DelayUs<u32>,
+                    D: DelayNs
                 {
                     let dac = unsafe { &(*<$DAC>::ptr()) };
                     dac.dac_cr.modify(|_, w| w.$en().clear_bit());

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -44,10 +44,10 @@ use fugit::ExtU32Ceil;
 
 use crate::nb::block;
 use crate::time::ExtU32;
-use embedded_hal::blocking::delay::{DelayMs, DelayUs};
-use embedded_hal_one::delay::DelayNs;
+use embedded_hal_old::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal::delay::DelayNs;
 
-pub trait CountDown: embedded_hal::timer::CountDown {
+pub trait CountDown: embedded_hal_old::timer::CountDown {
     fn max_period(&self) -> MicroSecond;
 }
 

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -44,8 +44,8 @@ use fugit::ExtU32Ceil;
 
 use crate::nb::block;
 use crate::time::ExtU32;
-use embedded_hal_old::blocking::delay::{DelayMs, DelayUs};
 use embedded_hal::delay::DelayNs;
+use embedded_hal_old::blocking::delay::{DelayMs, DelayUs};
 
 pub trait CountDown: embedded_hal_old::timer::CountDown {
     fn max_period(&self) -> MicroSecond;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,9 +1,9 @@
 //! Delay providers
 //!
 //! There are currently two delay providers. In general you should prefer to use
-//! [Delay](Delay), however if you do not have access to `SYST` you can use
-//! [DelayFromCountDownTimer](DelayFromCountDownTimer) with any timer that
-//! implements the [CountDown](embedded_hal::timer::CountDown) trait. This can be
+//! [Delay], however if you do not have access to `SYST` you can use
+//! [DelayFromCountDownTimer] with any timer that
+//! implements the [CountDown](embedded_hal_old::timer::CountDown) trait. This can be
 //! useful if you're using [RTIC](https://rtic.rs)'s schedule API, which occupies
 //! the `SYST` peripheral.
 //!

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -13,7 +13,7 @@
 //! instructions in DMA controller configuration.
 //!
 //! Adapted from
-//! https://github.com/stm32-rs/stm32h7xx-hal/blob/master/src/dma/mod.rs
+//! <https://github.com/stm32-rs/stm32h7xx-hal/blob/master/src/dma/mod.rs>
 
 use core::fmt::Debug;
 

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -1,7 +1,7 @@
 //! Traits for DMA types
 //!
 //! Adapted from
-//! https://github.com/stm32-rs/stm32f4xx-hal/blob/master/src/dma/traits.rs
+//! <https://github.com/stm32-rs/stm32f4xx-hal/blob/master/src/dma/traits.rs>
 
 use super::*;
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -333,16 +333,6 @@ macro_rules! gpio {
                 }
             }
 
-            impl<MODE> hal1::digital::ToggleableOutputPin for $PXx<Output<MODE>> {
-                fn toggle(&mut self) -> Result<(), Self::Error> {
-                    if <Self as hal1::digital::StatefulOutputPin>::is_set_high(self)? {
-                        <Self as hal1::digital::OutputPin>::set_low(self)
-                    } else {
-                        <Self as hal1::digital::OutputPin>::set_high(self)
-                    }
-                }
-            }
-
             impl<MODE> toggleable::Default for $PXx<Output<MODE>> {}
 
             impl<MODE> InputPin for $PXx<Output<MODE>> {
@@ -697,16 +687,6 @@ macro_rules! gpio {
                 }
 
                 impl<MODE> toggleable::Default for $PXi<Output<MODE>> {}
-
-                impl<MODE> hal1::digital::ToggleableOutputPin for $PXi<Output<MODE>> {
-                    fn toggle(&mut self) -> Result<(), Self::Error> {
-                        if <Self as hal1::digital::StatefulOutputPin>::is_set_high(self)? {
-                            <Self as hal1::digital::OutputPin>::set_low(self)
-                        } else {
-                            <Self as hal1::digital::OutputPin>::set_high(self)
-                        }
-                    }
-                }
 
                 impl<MODE> InputPin for $PXi<Output<MODE>> {
                     type Error = ();

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -240,8 +240,7 @@ macro_rules! gpio {
         /// GPIO
         pub mod $gpiox {
             use core::marker::PhantomData;
-            use hal::digital::v2::{toggleable, InputPin, OutputPin, StatefulOutputPin};
-            use embedded_hal_one as hal1;
+            use embedded_hal_old::digital::v2::{toggleable, InputPin, OutputPin, StatefulOutputPin};
             use crate::stm32::{EXTI, $GPIOX};
             use crate::exti::{ExtiExt, Event};
             use crate::rcc::Rcc;
@@ -289,11 +288,11 @@ macro_rules! gpio {
                 }
             }
 
-            impl<MODE> hal1::digital::ErrorType for $PXx<Output<MODE>> {
+            impl<MODE> embedded_hal::digital::ErrorType for $PXx<Output<MODE>> {
                 type Error = core::convert::Infallible;
             }
 
-            impl<MODE> hal1::digital::OutputPin for $PXx<Output<MODE>> {
+            impl<MODE> embedded_hal::digital::OutputPin for $PXx<Output<MODE>> {
                 fn set_high(&mut self) -> Result<(), Self::Error> {
                     // NOTE(unsafe) atomic write to a stateless register
                     unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << self.i)) };
@@ -320,7 +319,7 @@ macro_rules! gpio {
                 }
             }
 
-            impl<MODE> hal1::digital::StatefulOutputPin for $PXx<Output<MODE>> {
+            impl<MODE> embedded_hal::digital::StatefulOutputPin for $PXx<Output<MODE>> {
                 fn is_set_high(&mut self) -> Result<bool, Self::Error> {
                     let is_set_high = !self.is_set_low()?;
                     Ok(is_set_high)
@@ -350,7 +349,7 @@ macro_rules! gpio {
                 }
             }
 
-            impl<MODE> hal1::digital::InputPin for $PXx<Output<MODE>> {
+            impl<MODE> embedded_hal::digital::InputPin for $PXx<Output<MODE>> {
                 fn is_high(&mut self) -> Result<bool, Self::Error> {
                     let is_high = !self.is_low()?;
                     Ok(is_high)
@@ -379,11 +378,11 @@ macro_rules! gpio {
                 }
             }
 
-            impl<MODE> hal1::digital::ErrorType for $PXx<Input<MODE>> {
+            impl<MODE> embedded_hal::digital::ErrorType for $PXx<Input<MODE>> {
                 type Error = core::convert::Infallible;
             }
 
-            impl<MODE> hal1::digital::InputPin for $PXx<Input<MODE>> {
+            impl<MODE> embedded_hal::digital::InputPin for $PXx<Input<MODE>> {
                 fn is_high(&mut self) -> Result<bool, Self::Error> {
                     let is_high = !self.is_low()?;
                     Ok(is_high)
@@ -642,11 +641,11 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> hal1::digital::ErrorType for $PXi<Output<MODE>> {
+                impl<MODE> embedded_hal::digital::ErrorType for $PXi<Output<MODE>> {
                     type Error = core::convert::Infallible;
                 }
 
-                impl<MODE> hal1::digital::OutputPin for $PXi<Output<MODE>> {
+                impl<MODE> embedded_hal::digital::OutputPin for $PXi<Output<MODE>> {
                     fn set_high(&mut self) -> Result<(), Self::Error> {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << $i)) };
@@ -673,7 +672,7 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> hal1::digital::StatefulOutputPin for $PXi<Output<MODE>> {
+                impl<MODE> embedded_hal::digital::StatefulOutputPin for $PXi<Output<MODE>> {
                     fn is_set_high(&mut self) -> Result<bool, Self::Error> {
                         let is_set_high = !self.is_set_low()?;
                         Ok(is_set_high)
@@ -703,7 +702,7 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> hal1::digital::InputPin for $PXi<Output<MODE>> {
+                impl<MODE> embedded_hal::digital::InputPin for $PXi<Output<MODE>> {
                     fn is_high(&mut self) -> Result<bool, Self::Error> {
                         let is_high = !self.is_low()?;
                         Ok(is_high)
@@ -726,11 +725,11 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> hal1::digital::ErrorType for $PXi<Input<MODE>> {
+                impl<MODE> embedded_hal::digital::ErrorType for $PXi<Input<MODE>> {
                     type Error = core::convert::Infallible;
                 }
                 
-                impl<MODE> hal1::digital::InputPin for $PXi<Input<MODE>> {
+                impl<MODE> embedded_hal::digital::InputPin for $PXi<Input<MODE>> {
                     fn is_high(&mut self) -> Result<bool, Self::Error> {
                         let is_high = !self.is_low()?;
                         Ok(is_high)

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -728,7 +728,7 @@ macro_rules! gpio {
                 impl<MODE> embedded_hal::digital::ErrorType for $PXi<Input<MODE>> {
                     type Error = core::convert::Infallible;
                 }
-                
+
                 impl<MODE> embedded_hal::digital::InputPin for $PXi<Input<MODE>> {
                     fn is_high(&mut self) -> Result<bool, Self::Error> {
                         let is_high = !self.is_low()?;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,6 @@
 //! I2C
-use hal::blocking::i2c::{Read, Write, WriteRead};
-use embedded_hal_one::i2c::{ErrorKind, Operation, SevenBitAddress, TenBitAddress};
+use embedded_hal_old::blocking::i2c::{Read, Write, WriteRead};
+use embedded_hal::i2c::{ErrorKind, Operation, SevenBitAddress, TenBitAddress};
 
 use crate::gpio::{gpioa::*, gpiob::*, gpioc::*, gpiof::*};
 #[cfg(any(
@@ -128,11 +128,11 @@ pub enum Error {
     ArbitrationLost,
 }
 
-impl embedded_hal_one::i2c::Error for Error {
-    fn kind(&self) -> embedded_hal_one::i2c::ErrorKind {
+impl embedded_hal::i2c::Error for Error {
+    fn kind(&self) -> embedded_hal::i2c::ErrorKind {
         match self {
             Self::Overrun => ErrorKind::Overrun,
-            Self::Nack => ErrorKind::NoAcknowledge(embedded_hal_one::i2c::NoAcknowledgeSource::Unknown),
+            Self::Nack => ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Unknown),
             Self::PECError => ErrorKind::Other,
             Self::BusError => ErrorKind::Bus,
             Self::ArbitrationLost => ErrorKind::ArbitrationLoss
@@ -364,12 +364,12 @@ macro_rules! i2c {
             }
         }
 
-        impl<SDA, SCL> embedded_hal_one::i2c::ErrorType for I2c<$I2CX, SDA, SCL> {
+        impl<SDA, SCL> embedded_hal::i2c::ErrorType for I2c<$I2CX, SDA, SCL> {
             type Error = Error;
         }
 
         // TODO: custom read/write/read_write impl with hardware stop logic
-        impl<SDA, SCL> embedded_hal_one::i2c::I2c for I2c<$I2CX, SDA, SCL> {
+        impl<SDA, SCL> embedded_hal::i2c::I2c for I2c<$I2CX, SDA, SCL> {
             fn transaction(
                 &mut self,
                 address: SevenBitAddress,
@@ -386,7 +386,7 @@ macro_rules! i2c {
                 })
             }
         }
-        impl<SDA, SCL> embedded_hal_one::i2c::I2c<TenBitAddress> for I2c<$I2CX, SDA, SCL> {
+        impl<SDA, SCL> embedded_hal::i2c::I2c<TenBitAddress> for I2c<$I2CX, SDA, SCL> {
             fn transaction(
                 &mut self,
                 address: TenBitAddress,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,6 @@
 //! I2C
-use embedded_hal_old::blocking::i2c::{Read, Write, WriteRead};
 use embedded_hal::i2c::{ErrorKind, Operation, SevenBitAddress, TenBitAddress};
+use embedded_hal_old::blocking::i2c::{Read, Write, WriteRead};
 
 use crate::gpio::{gpioa::*, gpiob::*, gpioc::*, gpiof::*};
 #[cfg(any(
@@ -135,7 +135,7 @@ impl embedded_hal::i2c::Error for Error {
             Self::Nack => ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Unknown),
             Self::PECError => ErrorKind::Other,
             Self::BusError => ErrorKind::Bus,
-            Self::ArbitrationLost => ErrorKind::ArbitrationLoss
+            Self::ArbitrationLost => ErrorKind::ArbitrationLoss,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,12 @@ extern crate bare_metal;
 extern crate void;
 
 pub extern crate cortex_m;
-pub extern crate embedded_hal as hal;
 pub extern crate nb;
 pub extern crate stm32g4;
 
 pub use nb::block;
+pub use embedded_hal as hal;
+pub use embedded_hal_old as hal_02;
 
 mod sealed {
     pub trait Sealed {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,9 +32,9 @@ pub extern crate cortex_m;
 pub extern crate nb;
 pub extern crate stm32g4;
 
-pub use nb::block;
 pub use embedded_hal as hal;
 pub use embedded_hal_old as hal_02;
+pub use nb::block;
 
 mod sealed {
     pub trait Sealed {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub use stm32g4::stm32g491 as stm32;
 #[cfg(feature = "stm32g4a1")]
 pub use stm32g4::stm32g4a1 as stm32;
 
+pub use stm32 as pac;
+
 #[cfg(feature = "rt")]
 pub use crate::stm32::interrupt;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,9 +1,15 @@
-pub use hal::digital::v2::*;
-pub use hal::prelude::*;
+pub use embedded_hal::{
+    delay::DelayNs,
+    digital::{InputPin, OutputPin, StatefulOutputPin},
+    i2c::I2c,
+    pwm::SetDutyCycle,
+    spi::SpiBus,
+};
 
-pub use hal::adc::OneShot as _;
-pub use hal::watchdog::Watchdog as _;
-pub use hal::watchdog::WatchdogEnable as _;
+pub use embedded_hal_old::{
+    adc::OneShot as _,
+    watchdog::{Watchdog as _, WatchdogEnable as _},
+};
 
 // pub use crate::analog::adc::AdcExt as _;
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -1405,7 +1405,7 @@ macro_rules! tim_hal {
             $(
                 impl<PINS, CHANNEL, COMP> PwmBuilder<$TIMX, PINS, CHANNEL, FaultDisabled, COMP, $typ> {
                     /// Configure a break pin that will disable PWM when activated (active level based on polarity argument)
-                    /// Note: not all timers have fault inputs; FaultPins<TIM> is only implemented for valid pins/timers.
+                    /// Note: not all timers have fault inputs; `FaultPins<TIM>` is only implemented for valid pins/timers.
                     pub fn with_break_pin<P: FaultPins<$TIMX>>(self, _pin: P, polarity: Polarity) -> PwmBuilder<$TIMX, PINS, CHANNEL, FaultEnabled, COMP, $typ> {
                         PwmBuilder {
                             _tim: PhantomData,

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -6,12 +6,13 @@ use crate::dma::{
 };
 use crate::gpio::{gpioa::*, gpiob::*, gpioc::*, gpiod::*, gpioe::*, gpiog::*};
 use crate::gpio::{Alternate, AlternateOD, AF12, AF5, AF7, AF8};
-use crate::prelude::*;
 use crate::rcc::{Enable, GetBusFreq, Rcc, RccBus, Reset};
 use crate::stm32::*;
 
 use cortex_m::interrupt;
 use nb::block;
+
+use embedded_hal_old::serial::Write;
 use embedded_io::{ReadReady, WriteReady};
 
 use crate::serial::config::*;
@@ -137,7 +138,7 @@ pub trait SerialExt<USART, Config> {
 
 impl<USART, TX, RX> fmt::Write for Serial<USART, TX, RX>
 where
-    Serial<USART, TX, RX>: hal::serial::Write<u8>,
+    Serial<USART, TX, RX>: embedded_hal_old::serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
@@ -147,7 +148,7 @@ where
 
 impl<USART, Pin, Dma> fmt::Write for Tx<USART, Pin, Dma>
 where
-    Tx<USART, Pin, Dma>: hal::serial::Write<u8>,
+    Tx<USART, Pin, Dma>: embedded_hal_old::serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
@@ -255,7 +256,7 @@ macro_rules! uart_shared {
             }
         }
 
-        impl<Pin> hal::serial::Read<u8> for Rx<$USARTX, Pin, NoDMA> {
+        impl<Pin> embedded_hal_old::serial::Read<u8> for Rx<$USARTX, Pin, NoDMA> {
             type Error = Error;
 
             fn read(&mut self) -> nb::Result<u8, Error> {
@@ -264,7 +265,7 @@ macro_rules! uart_shared {
             }
         }
 
-        impl<TX, RX> hal::serial::Read<u8> for Serial<$USARTX, TX, RX> {
+        impl<TX, RX> embedded_hal_old::serial::Read<u8> for Serial<$USARTX, TX, RX> {
             type Error = Error;
 
             fn read(&mut self) -> nb::Result<u8, Error> {
@@ -330,7 +331,7 @@ macro_rules! uart_shared {
             }
         }
 
-        impl<Pin> hal::serial::Write<u8> for Tx<$USARTX, Pin, NoDMA> {
+        impl<Pin> embedded_hal_old::serial::Write<u8> for Tx<$USARTX, Pin, NoDMA> {
             type Error = Error;
 
             fn flush(&mut self) -> nb::Result<(), Self::Error> {
@@ -353,7 +354,7 @@ macro_rules! uart_shared {
             }
         }
 
-        impl<TX, RX> hal::serial::Write<u8> for Serial<$USARTX, TX, RX> {
+        impl<TX, RX> embedded_hal_old::serial::Write<u8> for Serial<$USARTX, TX, RX> {
             type Error = Error;
 
             fn flush(&mut self) -> nb::Result<(), Self::Error> {
@@ -391,7 +392,7 @@ macro_rules! uart_shared {
                 Ok(count)
             }
             fn flush(&mut self) -> Result<(), Error> {
-                nb::block!(hal::serial::Write::<u8>::flush(self))
+                nb::block!(embedded_hal_old::serial::Write::<u8>::flush(self))
             }
         }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -24,8 +24,8 @@ use crate::time::Hertz;
 use core::cell::UnsafeCell;
 use core::ptr;
 
-pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 use embedded_hal::spi::ErrorKind;
+pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 
 /// SPI error
 #[derive(Debug)]
@@ -309,7 +309,7 @@ macro_rules! spi {
                     *r = nb::block!(self.nb_read())?;
                 }
                 read[common_len-1] = nb::block!(self.nb_read())?;
-                
+
                 if read.len() > common_len {
                     self.read(&mut read[common_len..])
                 } else {
@@ -325,7 +325,7 @@ macro_rules! spi {
                 for rw in cells.windows(2) {
                     let r = &rw[0];
                     let w = &rw[1];
-                    
+
                     nb::block!(self.nb_write(w.get()))?;
                     r.set(nb::block!(self.nb_read())?);
                 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -24,7 +24,8 @@ use crate::time::Hertz;
 use core::cell::UnsafeCell;
 use core::ptr;
 
-pub use hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+use embedded_hal::spi::ErrorKind;
 
 /// SPI error
 #[derive(Debug)]
@@ -37,12 +38,12 @@ pub enum Error {
     Crc,
 }
 
-impl embedded_hal_one::spi::Error for Error {
-    fn kind(&self) -> embedded_hal_one::spi::ErrorKind {
+impl embedded_hal::spi::Error for Error {
+    fn kind(&self) -> ErrorKind {
         match self {
-            Self::Overrun => embedded_hal_one::spi::ErrorKind::Overrun,
-            Self::ModeFault => embedded_hal_one::spi::ErrorKind::ModeFault,
-            Self::Crc => embedded_hal_one::spi::ErrorKind::Other,
+            Self::Overrun => ErrorKind::Overrun,
+            Self::ModeFault => ErrorKind::ModeFault,
+            Self::Crc => ErrorKind::Other,
         }
     }
 }
@@ -260,11 +261,11 @@ macro_rules! spi {
                 }
         }
 
-        impl<PINS> embedded_hal_one::spi::ErrorType for Spi<$SPIX, PINS> {
+        impl<PINS> embedded_hal::spi::ErrorType for Spi<$SPIX, PINS> {
             type Error = Error;
         }
 
-        impl<PINS> embedded_hal_one::spi::SpiBus for Spi<$SPIX, PINS> {
+        impl<PINS> embedded_hal::spi::SpiBus<u8> for Spi<$SPIX, PINS> {
             fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
                 if words.len() == 0 { return Ok(()) }
                 // clear tx-only status in the case the previous operation was a write
@@ -345,7 +346,7 @@ macro_rules! spi {
             }
         }
 
-        impl<PINS> hal::spi::FullDuplex<u8> for Spi<$SPIX, PINS> {
+        impl<PINS> embedded_hal_old::spi::FullDuplex<u8> for Spi<$SPIX, PINS> {
             type Error = Error;
 
             fn read(&mut self) -> nb::Result<u8, Error> {
@@ -369,9 +370,9 @@ macro_rules! spi {
         }
 
 
-        impl<PINS> ::hal::blocking::spi::transfer::Default<u8> for Spi<$SPIX, PINS> {}
+        impl<PINS> embedded_hal_old::blocking::spi::transfer::Default<u8> for Spi<$SPIX, PINS> {}
 
-        impl<PINS> ::hal::blocking::spi::write::Default<u8> for Spi<$SPIX, PINS> {}
+        impl<PINS> embedded_hal_old::blocking::spi::write::Default<u8> for Spi<$SPIX, PINS> {}
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -101,17 +101,17 @@ impl U32Ext for u32 {
     }
 }
 
-pub fn duration(hz: Hertz, cycles: u32) -> MicroSecond {
+pub fn duration<const NOM: u32, const DENOM: u32>(hz: Hertz, cycles: u32) -> Duration<u32, NOM, DENOM> {
     let cycles = cycles as u64;
     let clk = hz.raw() as u64;
-    let us = cycles.saturating_mul(1_000_000_u64) / clk;
-    MicroSecond::from_ticks(us as u32)
+    let us = cycles.saturating_mul(DENOM as u64) / clk / NOM as u64;
+    Duration::<u32, NOM, DENOM>::from_ticks(us as u32)
 }
 
-pub fn cycles(ms: MicroSecond, clk: Hertz) -> u32 {
+pub fn cycles<const NOM: u32, const DENOM: u32>(ms: Duration<u32, NOM, DENOM>, clk: Hertz) -> u32 {
     assert!(ms.ticks() > 0);
     let clk = clk.raw() as u64;
     let period = ms.ticks() as u64;
-    let cycles = clk.saturating_mul(period) / 1_000_000_u64;
+    let cycles = clk.saturating_mul(period).saturating_mul(NOM as u64) / DENOM as u64;
     cycles as u32
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -101,7 +101,10 @@ impl U32Ext for u32 {
     }
 }
 
-pub fn duration<const NOM: u32, const DENOM: u32>(hz: Hertz, cycles: u32) -> Duration<u32, NOM, DENOM> {
+pub fn duration<const NOM: u32, const DENOM: u32>(
+    hz: Hertz,
+    cycles: u32,
+) -> Duration<u32, NOM, DENOM> {
     let cycles = cycles as u64;
     let clk = hz.raw() as u64;
     let us = cycles.saturating_mul(DENOM as u64) / clk / NOM as u64;

--- a/src/time.rs
+++ b/src/time.rs
@@ -101,16 +101,18 @@ impl U32Ext for u32 {
     }
 }
 
+/// Converts clock cycles at a given frequency into a Duration with arbitrary fraction
 pub fn duration<const NOM: u32, const DENOM: u32>(
     hz: Hertz,
     cycles: u32,
 ) -> Duration<u32, NOM, DENOM> {
     let cycles = cycles as u64;
     let clk = hz.raw() as u64;
-    let us = cycles.saturating_mul(DENOM as u64) / clk / NOM as u64;
-    Duration::<u32, NOM, DENOM>::from_ticks(us as u32)
+    let duration_ticks = cycles.saturating_mul(DENOM as u64) / clk / NOM as u64;
+    Duration::<u32, NOM, DENOM>::from_ticks(duration_ticks as u32)
 }
 
+/// Converts a Duration with arbitrary fraction into a number of cycles at the specified frequency
 pub fn cycles<const NOM: u32, const DENOM: u32>(ms: Duration<u32, NOM, DENOM>, clk: Hertz) -> u32 {
     assert!(ms.ticks() > 0);
     let clk = clk.raw() as u64;

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -7,7 +7,7 @@ use crate::delay::CountDown;
 use cast::{u16, u32};
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::{DCB, DWT, SYST};
-use embedded_hal::timer::{Cancel, CountDown as _, Periodic};
+use embedded_hal_old::timer::{Cancel, CountDown as _, Periodic};
 use void::Void;
 
 use crate::stm32::RCC;
@@ -108,7 +108,7 @@ impl CountDownTimer<SYST> {
     }
 }
 
-impl embedded_hal::timer::CountDown for CountDownTimer<SYST> {
+impl embedded_hal_old::timer::CountDown for CountDownTimer<SYST> {
     type Time = MicroSecond;
 
     fn start<T>(&mut self, timeout: T)
@@ -289,7 +289,7 @@ macro_rules! hal {
                 }
             }
 
-            impl embedded_hal::timer::CountDown for CountDownTimer<$TIM> {
+            impl embedded_hal_old::timer::CountDown for CountDownTimer<$TIM> {
                 type Time = MicroSecond;
 
                 fn start<T>(&mut self, timeout: T)


### PR DESCRIPTION
Fixes #118 

The new traits are not feature gated, instead embedded_hal 0.2 is now exported as hal_02
Traits from embedded-hal 1.0 have replaced the old ones in the prelude