### PR TITLE
Fix `PLLSrc` enum not matching capitalisation conventions

### DIFF
--- a/examples/flash_with_rtic.rs
+++ b/examples/flash_with_rtic.rs
@@ -48,7 +48,7 @@ mod app {
         let mut pll_config = stm32g4xx_hal::rcc::PllConfig::default();
 
         // Sysclock is based on PLL_R
-        pll_config.mux = stm32g4xx_hal::rcc::PLLSrc::HSI; // 16MHz
+        pll_config.mux = stm32g4xx_hal::rcc::PllSrc::HSI; // 16MHz
         pll_config.n = stm32g4xx_hal::rcc::PllNMul::MUL_32;
         pll_config.m = stm32g4xx_hal::rcc::PllMDiv::DIV_2; // f(vco) = 16MHz*32/2 = 256MHz
         pll_config.r = Some(stm32g4xx_hal::rcc::PllRDiv::DIV_2); // f(sysclock) = 256MHz/2 = 128MHz

--- a/src/rcc/config.rs
+++ b/src/rcc/config.rs
@@ -40,7 +40,7 @@ pub enum LSCOSrc {
 
 /// PLL clock input source
 #[derive(Clone, Copy)]
-pub enum PLLSrc {
+pub enum PllSrc {
     HSI,
     HSE(Hertz),
     HSE_BYPASS(Hertz),
@@ -304,7 +304,7 @@ impl PllNMul {
 /// PLL config
 #[derive(Clone, Copy)]
 pub struct PllConfig {
-    pub mux: PLLSrc,
+    pub mux: PllSrc,
     pub m: PllMDiv,
     pub n: PllNMul,
     pub r: Option<PllRDiv>,
@@ -315,7 +315,7 @@ pub struct PllConfig {
 impl Default for PllConfig {
     fn default() -> PllConfig {
         PllConfig {
-            mux: PLLSrc::HSI,
+            mux: PllSrc::HSI,
             m: PllMDiv::DIV_2,
             n: PllNMul::MUL_8,
             r: Some(PllRDiv::DIV_2),

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -244,15 +244,15 @@ impl Rcc {
 
         // Enable the input clock feeding the PLL
         let (pll_input_freq, pll_src_bits) = match pll_cfg.mux {
-            PLLSrc::HSI => {
+            PllSrc::HSI => {
                 self.enable_hsi();
                 (HSI_FREQ, 0b10)
             }
-            PLLSrc::HSE(freq) => {
+            PllSrc::HSE(freq) => {
                 self.enable_hse(false);
                 (freq.raw(), 0b11)
             }
-            PLLSrc::HSE_BYPASS(freq) => {
+            PllSrc::HSE_BYPASS(freq) => {
                 self.enable_hse(true);
                 (freq.raw(), 0b11)
             }


### PR DESCRIPTION
`PLLSrc` -> `PllSrc`