### PR TITLE
rcc: Correct apb1_freq and apb2_freq calculations.

### DIFF
--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -109,18 +109,18 @@ impl Rcc {
             _ => (sys_freq, 0b0000),
         };
         let (apb1_freq, apb1_psc_bits) = match rcc_cfg.apb1_psc {
-            Prescaler::Div2 => (sys_freq / 2, 0b100),
-            Prescaler::Div4 => (sys_freq / 4, 0b101),
-            Prescaler::Div8 => (sys_freq / 8, 0b110),
-            Prescaler::Div16 => (sys_freq / 16, 0b111),
-            _ => (sys_freq, 0b000),
+            Prescaler::Div2 => (ahb_freq / 2, 0b100),
+            Prescaler::Div4 => (ahb_freq / 4, 0b101),
+            Prescaler::Div8 => (ahb_freq / 8, 0b110),
+            Prescaler::Div16 => (ahb_freq / 16, 0b111),
+            _ => (ahb_freq, 0b000),
         };
         let (apb2_freq, apb2_psc_bits) = match rcc_cfg.apb2_psc {
-            Prescaler::Div2 => (sys_freq / 2, 0b100),
-            Prescaler::Div4 => (sys_freq / 4, 0b101),
-            Prescaler::Div8 => (sys_freq / 8, 0b110),
-            Prescaler::Div16 => (sys_freq / 16, 0b111),
-            _ => (sys_freq, 0b000),
+            Prescaler::Div2 => (ahb_freq / 2, 0b100),
+            Prescaler::Div4 => (ahb_freq / 4, 0b101),
+            Prescaler::Div8 => (ahb_freq / 8, 0b110),
+            Prescaler::Div16 => (ahb_freq / 16, 0b111),
+            _ => (ahb_freq, 0b000),
         };
 
         let present_vos_mode = pwr::current_vos();


### PR DESCRIPTION
As per the Reference Manual Clock Tree (figure 17), these frequencies are divided from `ahb_freq` (HCLK) not `sys_clk` (SYSCLK).

<img src="https://github.com/user-attachments/assets/5e2b754e-15b0-4f69-b311-bce811efa0f4" width="500" alt="Segment of Figure 17" />

Thanks for all your work maintaining this crate!
