### PR TITLE
Allow to "freeze" gpio type state

### DIFF
--- a/examples/comp.rs
+++ b/examples/comp.rs
@@ -46,7 +46,7 @@ fn main() -> ! {
             .output_inverted(),
         &rcc.clocks,
     );
-    let led2 = gpioa.pa12.into_push_pull_output();
+    let led2 = gpioa.pa12.into_alternate();
     // Configure PA12 to the comparator's alternate function so it gets
     // changed directly by the comparator.
     comp2.output_pin(led2);

--- a/examples/comp_w_dac.rs
+++ b/examples/comp_w_dac.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
     // Set up DAC to output to pa4 and to internal signal Dac1IntSig1
     // which just so happens is compatible with comp1
     let dac1ch1 = dp.DAC1.constrain((gpioa.pa4, Dac1IntSig1), &mut rcc);
-    let mut dac = dac1ch1.calibrate_buffer(&mut delay).enable();
+    let mut dac = dac1ch1.calibrate_buffer(&mut delay).enable().freeze();
 
     let (comp1, _comp2, ..) = dp.COMP.split(&mut rcc);
     let pa1 = gpioa.pa1.into_analog();

--- a/examples/comp_w_dac.rs
+++ b/examples/comp_w_dac.rs
@@ -43,7 +43,7 @@ fn main() -> ! {
         &rcc.clocks,
     );
 
-    let led2 = gpioa.pa0.into_push_pull_output();
+    let led2 = gpioa.pa0.into_alternate();
     // Configure PA12 to the comparator's alternate function so it gets
     // changed directly by the comparator.
     comp.output_pin(led2);

--- a/examples/opamp.rs
+++ b/examples/opamp.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
 
     // Configure opamp1 with pa1 as non-inverting input and set gain to x2
     let _opamp1 = opamp1.pga(&pa1, pa2, Gain::Gain2);
-    
+
     // Set up opamp2 in follower mode with output routed to internal ADC
     let opamp2 = opamp2.follower(&pa7, InternalOutput);
 

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -10,7 +10,6 @@ use core::marker::PhantomData;
 
 use crate::dac;
 use crate::exti::{Event as ExtiEvent, ExtiExt};
-use crate::gpio::{FrozenPin, IsFrozen};
 use crate::gpio::{
     gpioa::{PA0, PA1, PA11, PA12, PA2, PA3, PA4, PA5, PA6, PA7},
     gpiob::{PB0, PB1, PB14, PB15, PB2, PB6, PB7, PB8, PB9},
@@ -18,6 +17,7 @@ use crate::gpio::{
     gpiof::PF4,
     Alternate, AlternateOD, Analog, SignalEdge, AF2, AF3, AF8,
 };
+use crate::gpio::{FrozenPin, IsFrozen};
 
 #[cfg(any(
     feature = "stm32g473",
@@ -143,9 +143,9 @@ pub enum Hysteresis {
 /// Comparator positive input
 pub trait PositiveInput<C>: crate::Sealed {
     /// Setup comaprator to use this as its positive input
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// Internal use only
     unsafe fn setup(&self, comp: &mut C);
 }
@@ -165,7 +165,7 @@ pub trait NegativeInput<C>: crate::Sealed {
     /// Setup comaprator to use this as its negative input
     ///
     /// # Safety
-    /// 
+    ///
     /// Internal use only
     unsafe fn setup(&self, comp: &mut C);
 }
@@ -436,7 +436,7 @@ macro_rules! impl_comparator {
             ) -> Comparator<$COMP, Disabled>
             where
                 PP: FrozenPin<P> + PositiveInput<$COMP>,
-                NP: FrozenPin<N> + NegativeInput<$COMP>
+                NP: FrozenPin<N> + NegativeInput<$COMP>,
             {
                 unsafe {
                     positive_input.borrow().setup(&mut self);
@@ -474,7 +474,7 @@ macro_rules! impl_comparator {
             ) -> Self
             where
                 PP: FrozenPin<P> + PositiveInput<$COMP>,
-                NP: FrozenPin<N> + NegativeInput<$COMP>
+                NP: FrozenPin<N> + NegativeInput<$COMP>,
             {
                 comp.comparator(positive_input, negative_input, config, clocks)
             }

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -17,7 +17,7 @@ use crate::gpio::{
     gpiof::PF4,
     Alternate, AlternateOD, Analog, SignalEdge, AF2, AF3, AF8,
 };
-use crate::gpio::{FrozenPin, IsFrozen};
+use crate::gpio::{Frozen, IsFrozen};
 
 #[cfg(any(
     feature = "stm32g473",
@@ -281,7 +281,7 @@ pub enum RefintInput {
     VRefint = 0b011,
 }
 
-impl FrozenPin<RefintInput> for RefintInput {}
+impl Frozen<RefintInput> for RefintInput {}
 impl crate::Sealed for RefintInput {}
 
 macro_rules! refint_input {
@@ -420,8 +420,8 @@ pub trait ComparatorExt<COMP> {
         clocks: &Clocks,
     ) -> Comparator<COMP, Disabled>
     where
-        PP: FrozenPin<P> + PositiveInput<COMP>,
-        NP: FrozenPin<N> + NegativeInput<COMP>;
+        PP: Frozen<P> + PositiveInput<COMP>,
+        NP: Frozen<N> + NegativeInput<COMP>;
 }
 
 macro_rules! impl_comparator {
@@ -435,8 +435,8 @@ macro_rules! impl_comparator {
                 clocks: &Clocks,
             ) -> Comparator<$COMP, Disabled>
             where
-                PP: FrozenPin<P> + PositiveInput<$COMP>,
-                NP: FrozenPin<N> + NegativeInput<$COMP>,
+                PP: Frozen<P> + PositiveInput<$COMP>,
+                NP: Frozen<N> + NegativeInput<$COMP>,
             {
                 unsafe {
                     positive_input.borrow().setup(&mut self);
@@ -473,8 +473,8 @@ macro_rules! impl_comparator {
                 clocks: &Clocks,
             ) -> Self
             where
-                PP: FrozenPin<P> + PositiveInput<$COMP>,
-                NP: FrozenPin<N> + NegativeInput<$COMP>,
+                PP: Frozen<P> + PositiveInput<$COMP>,
+                NP: Frozen<N> + NegativeInput<$COMP>,
             {
                 comp.comparator(positive_input, negative_input, config, clocks)
             }

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -14,7 +14,7 @@ use crate::gpio::{
     gpiob::{PB0, PB1, PB14, PB15, PB2, PB6, PB7, PB8, PB9},
     gpioc::PC2,
     gpiof::PF4,
-    Analog, OpenDrain, Output, PushPull, SignalEdge, AF2, AF3, AF8,
+    Analog, Alternate, AlternateOD, SignalEdge, AF2, AF3, AF8,
 };
 
 #[cfg(any(
@@ -486,9 +486,7 @@ macro_rules! impl_comparator {
             /// Configures a GPIO pin to output the signal of the comparator
             ///
             /// Multiple GPIO pins may be configured as the output simultaneously.
-            pub fn output_pin<P: OutputPin<$COMP>>(&self, pin: P) {
-                pin.setup();
-            }
+            pub fn output_pin<P: OutputPin<$COMP>>(&self, _pin: P) {}
         }
     };
 }
@@ -587,22 +585,16 @@ impl ComparatorSplit for COMP {
     }
 }
 
-pub trait OutputPin<COMP> {
-    fn setup(self);
-}
+pub trait OutputPin<COMP> {}
 
 #[allow(unused_macros)] // TODO: add support for more devices
 macro_rules! output_pin {
-    ($COMP:ident, $pin:ident, $AF:ident, $mode_t:ident, $into:ident) => {
-        impl OutputPin<$COMP> for $pin<Output<$mode_t>> {
-            fn setup(self) {
-                self.$into::<$AF>();
-            }
-        }
+    ($COMP:ident, $pin:ident, $AF:ident, $mode_t:ident) => {
+        impl OutputPin<$COMP> for $pin<$mode_t<$AF>> {}
     };
     ($($COMP:ident: $pin:ident, $AF:ident,)+) => {$(
-        output_pin!($COMP, $pin, $AF, PushPull, into_alternate);
-        output_pin!($COMP, $pin, $AF, OpenDrain, into_alternate_open_drain);
+        output_pin!($COMP, $pin, $AF, Alternate);
+        output_pin!($COMP, $pin, $AF, AlternateOD);
     )+};
 }
 

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -9,7 +9,7 @@ use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
 use crate::gpio::gpioa::{PA4, PA5, PA6};
-use crate::gpio::{DefaultMode, FrozenPin, IsFrozen, IsNotFrozen};
+use crate::gpio::{DefaultMode, Frozen, IsFrozen, IsNotFrozen};
 use crate::rcc::{self, *};
 use crate::stm32::{DAC1, DAC2, DAC3, DAC4, RCC};
 use hal::blocking::delay::DelayUs;
@@ -69,10 +69,10 @@ macro_rules! impl_dac {
             _frozen_state: PhantomData<F>,
         }
 
-        impl<const M: u8> FrozenPin<$DACxCHy<M, Enabled, IsFrozen>> for $DACxCHy<M, Enabled>{}
-        impl<const M: u8> FrozenPin<$DACxCHy<M, Enabled, IsFrozen>> for $DACxCHy<M, WaveGenerator>{}
-        impl<const M: u8> FrozenPin<$DACxCHy<M, Enabled, IsFrozen>> for &$DACxCHy<M, Enabled, IsFrozen>{}
-        impl<const M: u8> FrozenPin<$DACxCHy<M, Enabled, IsFrozen>> for &$DACxCHy<M, WaveGenerator, IsFrozen>{}
+        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for $DACxCHy<M, Enabled>{}
+        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for $DACxCHy<M, WaveGenerator>{}
+        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for &$DACxCHy<M, Enabled, IsFrozen>{}
+        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for &$DACxCHy<M, WaveGenerator, IsFrozen>{}
 
         impl<const M: u8> crate::Sealed for $DACxCHy<M, Enabled>{}
         impl<const M: u8> crate::Sealed for $DACxCHy<M, WaveGenerator>{}

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -69,15 +69,21 @@ macro_rules! impl_dac {
             _frozen_state: PhantomData<F>,
         }
 
-        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for $DACxCHy<M, Enabled>{}
-        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for $DACxCHy<M, WaveGenerator>{}
-        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for &$DACxCHy<M, Enabled, IsFrozen>{}
-        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for &$DACxCHy<M, WaveGenerator, IsFrozen>{}
+        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for $DACxCHy<M, Enabled> {}
+        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>> for $DACxCHy<M, WaveGenerator> {}
+        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>>
+            for &$DACxCHy<M, Enabled, IsFrozen>
+        {
+        }
+        impl<const M: u8> Frozen<$DACxCHy<M, Enabled, IsFrozen>>
+            for &$DACxCHy<M, WaveGenerator, IsFrozen>
+        {
+        }
 
-        impl<const M: u8> crate::Sealed for $DACxCHy<M, Enabled>{}
-        impl<const M: u8> crate::Sealed for $DACxCHy<M, WaveGenerator>{}
-        impl<const M: u8> crate::Sealed for &$DACxCHy<M, Enabled, IsFrozen>{}
-        impl<const M: u8> crate::Sealed for &$DACxCHy<M, WaveGenerator, IsFrozen>{}
+        impl<const M: u8> crate::Sealed for $DACxCHy<M, Enabled> {}
+        impl<const M: u8> crate::Sealed for $DACxCHy<M, WaveGenerator> {}
+        impl<const M: u8> crate::Sealed for &$DACxCHy<M, Enabled, IsFrozen> {}
+        impl<const M: u8> crate::Sealed for &$DACxCHy<M, WaveGenerator, IsFrozen> {}
     };
 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -32,13 +32,49 @@ pub struct IsNotFrozen;
 ///
 /// It is also implemented for reference to a frozen pin `&$PXi<MODE, IsFrozen>`, since they can not change mode due to being frozen.
 pub trait FrozenPin<T>: crate::Sealed {}
-impl<A1, A2, B1, B2> FrozenPin<(B1, B2)> for (A1, A2) where A1: FrozenPin<B1>, A2: FrozenPin<B2> {}
-impl<A1, A2, A3, B1, B2, B3> FrozenPin<(B1, B2, B3)> for (A1, A2, A3) where A1: FrozenPin<B1>, A2: FrozenPin<B2>, A3: FrozenPin<B3> {}
-impl<A1, A2, A3, A4, B1, B2, B3, B4> FrozenPin<(B1, B2, B3, B4)> for (A1, A2, A3, A4) where A1: FrozenPin<B1>, A2: FrozenPin<B2>, A3: FrozenPin<B3>, A4: FrozenPin<B4> {}
+impl<A1, A2, B1, B2> FrozenPin<(B1, B2)> for (A1, A2)
+where
+    A1: FrozenPin<B1>,
+    A2: FrozenPin<B2>,
+{
+}
+impl<A1, A2, A3, B1, B2, B3> FrozenPin<(B1, B2, B3)> for (A1, A2, A3)
+where
+    A1: FrozenPin<B1>,
+    A2: FrozenPin<B2>,
+    A3: FrozenPin<B3>,
+{
+}
+impl<A1, A2, A3, A4, B1, B2, B3, B4> FrozenPin<(B1, B2, B3, B4)> for (A1, A2, A3, A4)
+where
+    A1: FrozenPin<B1>,
+    A2: FrozenPin<B2>,
+    A3: FrozenPin<B3>,
+    A4: FrozenPin<B4>,
+{
+}
 
-impl<A1, A2> crate::Sealed for (A1, A2) where A1: crate::Sealed, A2: crate::Sealed {}
-impl<A1, A2, A3> crate::Sealed for (A1, A2, A3) where A1: crate::Sealed, A2: crate::Sealed, A3: crate::Sealed {}
-impl<A1, A2, A3, A4> crate::Sealed for (A1, A2, A3, A4) where A1: crate::Sealed, A2: crate::Sealed, A3: crate::Sealed, A4: crate::Sealed {}
+impl<A1, A2> crate::Sealed for (A1, A2)
+where
+    A1: crate::Sealed,
+    A2: crate::Sealed,
+{
+}
+impl<A1, A2, A3> crate::Sealed for (A1, A2, A3)
+where
+    A1: crate::Sealed,
+    A2: crate::Sealed,
+    A3: crate::Sealed,
+{
+}
+impl<A1, A2, A3, A4> crate::Sealed for (A1, A2, A3, A4)
+where
+    A1: crate::Sealed,
+    A2: crate::Sealed,
+    A3: crate::Sealed,
+    A4: crate::Sealed,
+{
+}
 
 /// Input mode (type state)
 pub struct Input<MODE> {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -31,26 +31,26 @@ pub struct IsNotFrozen;
 /// This is implemented for all owned pins since no one else can change their mode once ownership is passed on to the peripheral.
 ///
 /// It is also implemented for reference to a frozen pin `&$PXi<MODE, IsFrozen>`, since they can not change mode due to being frozen.
-pub trait FrozenPin<T>: crate::Sealed {}
-impl<A1, A2, B1, B2> FrozenPin<(B1, B2)> for (A1, A2)
+pub trait Frozen<T>: crate::Sealed {}
+impl<A1, A2, B1, B2> Frozen<(B1, B2)> for (A1, A2)
 where
-    A1: FrozenPin<B1>,
-    A2: FrozenPin<B2>,
+    A1: Frozen<B1>,
+    A2: Frozen<B2>,
 {
 }
-impl<A1, A2, A3, B1, B2, B3> FrozenPin<(B1, B2, B3)> for (A1, A2, A3)
+impl<A1, A2, A3, B1, B2, B3> Frozen<(B1, B2, B3)> for (A1, A2, A3)
 where
-    A1: FrozenPin<B1>,
-    A2: FrozenPin<B2>,
-    A3: FrozenPin<B3>,
+    A1: Frozen<B1>,
+    A2: Frozen<B2>,
+    A3: Frozen<B3>,
 {
 }
-impl<A1, A2, A3, A4, B1, B2, B3, B4> FrozenPin<(B1, B2, B3, B4)> for (A1, A2, A3, A4)
+impl<A1, A2, A3, A4, B1, B2, B3, B4> Frozen<(B1, B2, B3, B4)> for (A1, A2, A3, A4)
 where
-    A1: FrozenPin<B1>,
-    A2: FrozenPin<B2>,
-    A3: FrozenPin<B3>,
-    A4: FrozenPin<B4>,
+    A1: Frozen<B1>,
+    A2: Frozen<B2>,
+    A3: Frozen<B3>,
+    A4: Frozen<B4>,
 {
 }
 
@@ -402,8 +402,8 @@ macro_rules! gpio {
                     _frozen_state: PhantomData<F>,
                 }
 
-                impl<MODE> FrozenPin<$PXi<MODE, IsFrozen>> for $PXi<MODE> {}
-                impl<MODE> FrozenPin<$PXi<MODE, IsFrozen>> for &$PXi<MODE, IsFrozen> {}
+                impl<MODE> Frozen<$PXi<MODE, IsFrozen>> for $PXi<MODE> {}
+                impl<MODE> Frozen<$PXi<MODE, IsFrozen>> for &$PXi<MODE, IsFrozen> {}
                 impl<MODE, F> crate::Sealed for $PXi<MODE, F> {}
                 impl<MODE> crate::Sealed for &$PXi<MODE, IsFrozen> {}
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -353,43 +353,43 @@ macro_rules! gpio {
                 }
 
                 #[allow(clippy::from_over_into)]
-                impl<F> Into<$PXi<Input<PullDown>, F>> for $PXi<DefaultMode> {
-                    fn into(self) -> $PXi<Input<PullDown>, F> {
+                impl Into<$PXi<Input<PullDown>>> for $PXi<DefaultMode> {
+                    fn into(self) -> $PXi<Input<PullDown>> {
                         self.into_pull_down_input()
                     }
                 }
 
                 #[allow(clippy::from_over_into)]
-                impl<F> Into<$PXi<Input<PullUp>, F>> for $PXi<DefaultMode> {
-                    fn into(self) -> $PXi<Input<PullUp>, F> {
+                impl Into<$PXi<Input<PullUp>>> for $PXi<DefaultMode> {
+                    fn into(self) -> $PXi<Input<PullUp>> {
                         self.into_pull_up_input()
                     }
                 }
 
                 #[allow(clippy::from_over_into)]
-                impl<F> Into<$PXi<Analog, F>> for $PXi<DefaultMode> {
-                    fn into(self) -> $PXi<Analog, F> {
+                impl Into<$PXi<Analog>> for $PXi<DefaultMode> {
+                    fn into(self) -> $PXi<Analog, IsNotFrozen> {
                         self.into_analog()
                     }
                 }
 
                 #[allow(clippy::from_over_into)]
-                impl<F> Into<$PXi<Output<OpenDrain>, F>> for $PXi<DefaultMode> {
-                    fn into(self) -> $PXi<Output<OpenDrain>, F> {
+                impl Into<$PXi<Output<OpenDrain>>> for $PXi<DefaultMode> {
+                    fn into(self) -> $PXi<Output<OpenDrain>> {
                         self.into_open_drain_output()
                     }
                 }
 
                 #[allow(clippy::from_over_into)]
-                impl<F> Into<$PXi<Output<PushPull>, F>> for $PXi<DefaultMode> {
-                    fn into(self) -> $PXi<Output<PushPull>, F> {
+                impl Into<$PXi<Output<PushPull>>> for $PXi<DefaultMode> {
+                    fn into(self) -> $PXi<Output<PushPull>> {
                         self.into_push_pull_output()
                     }
                 }
 
                 impl<MODE> $PXi<MODE, IsNotFrozen> {
                     /// Configures the pin to operate as a floating input pin
-                    pub fn into_floating_input<F>(self) -> $PXi<Input<Floating>, F> {
+                    pub fn into_floating_input(self) -> $PXi<Input<Floating>> {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
@@ -404,7 +404,7 @@ macro_rules! gpio {
                     }
 
                     /// Configures the pin to operate as a pulled down input pin
-                    pub fn into_pull_down_input<F>(self) -> $PXi<Input<PullDown>, F> {
+                    pub fn into_pull_down_input(self) -> $PXi<Input<PullDown>> {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
@@ -419,7 +419,7 @@ macro_rules! gpio {
                     }
 
                     /// Configures the pin to operate as a pulled up input pin
-                    pub fn into_pull_up_input<F>(self) -> $PXi<Input<PullUp>, F> {
+                    pub fn into_pull_up_input(self) -> $PXi<Input<PullUp>> {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
@@ -449,7 +449,7 @@ macro_rules! gpio {
                     }
 
                     /// Configures the pin to operate as an open drain output pin
-                    pub fn into_open_drain_output<F>(self) -> $PXi<Output<OpenDrain>, F> {
+                    pub fn into_open_drain_output(self) -> $PXi<Output<OpenDrain>> {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());
@@ -467,7 +467,7 @@ macro_rules! gpio {
                     }
 
                     /// Configures the pin to operate as an push pull output pin
-                    pub fn into_push_pull_output<F>(self) -> $PXi<Output<PushPull>, F> {
+                    pub fn into_push_pull_output(self) -> $PXi<Output<PushPull>> {
                         let offset = 2 * $i;
                         unsafe {
                             let gpio = &(*$GPIOX::ptr());

--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -79,7 +79,7 @@ use crate::gpio::{
     gpiod::{PD11, PD12, PD8, PD9},
 };
 
-use crate::gpio::{Analog, FrozenPin, IsFrozen};
+use crate::gpio::{Analog, Frozen, IsFrozen};
 use core::marker::PhantomData;
 
 /// PGA Gain
@@ -169,14 +169,14 @@ where
         gain: Gain,
     ) -> Pga<Opamp, NonInverting, Output>
     where
-        IP: FrozenPin<NonInverting>,
-        OP: FrozenPin<Output>;
+        IP: Frozen<NonInverting>,
+        OP: Frozen<Output>;
 
     /// Trait for opamps that can be run in programmable gain mode,
     /// with external filtering.
     fn pga_external_filter<
-        P1: FrozenPin<NonInverting>,
-        P2: FrozenPin<<Opamp as ConfigurePgaReg<Opamp, NonInverting>>::Vinm0>,
+        P1: Frozen<NonInverting>,
+        P2: Frozen<<Opamp as ConfigurePgaReg<Opamp, NonInverting>>::Vinm0>,
     >(
         self,
         non_inverting: P1,
@@ -188,8 +188,8 @@ where
     /// Configures the opamp for programmable gain operation, with
     /// external filtering.
     fn pga_external_bias<
-        B1: FrozenPin<NonInverting>,
-        B2: FrozenPin<<Opamp as ConfigurePgaReg<Opamp, NonInverting>>::Vinm0>,
+        B1: Frozen<NonInverting>,
+        B2: Frozen<<Opamp as ConfigurePgaReg<Opamp, NonInverting>>::Vinm0>,
     >(
         self,
         non_inverting: B1,
@@ -201,9 +201,9 @@ where
     /// Configures the opamp for programmable gain operation, with
     /// external filtering.
     fn pga_external_bias_and_filter<
-        B1: FrozenPin<NonInverting>,
-        B2: FrozenPin<<Opamp as ConfigurePgaReg<Opamp, NonInverting>>::Vinm0>,
-        B3: FrozenPin<<Opamp as ConfigurePgaReg<Opamp, NonInverting>>::Vinm1>,
+        B1: Frozen<NonInverting>,
+        B2: Frozen<<Opamp as ConfigurePgaReg<Opamp, NonInverting>>::Vinm0>,
+        B3: Frozen<<Opamp as ConfigurePgaReg<Opamp, NonInverting>>::Vinm1>,
     >(
         self,
         non_inverting: B1,
@@ -502,7 +502,7 @@ macro_rules! opamps {
             $(
             impl <Input, IntoOutput> IntoFollower <$opamp, Input, IntoOutput, $input, $output> for Disabled<$opamp>
                 where
-                    Input: FrozenPin<$input>,
+                    Input: Frozen<$input>,
                     IntoOutput: Into<$output>,
             {
                 #[inline]
@@ -517,7 +517,7 @@ macro_rules! opamps {
 
             impl <Input> IntoFollower <$opamp, Input, InternalOutput, $input, InternalOutput> for Disabled<$opamp>
                 where
-                    Input: FrozenPin<$input>,
+                    Input: Frozen<$input>,
             {
                 fn follower(
                     self,
@@ -580,8 +580,8 @@ macro_rules! opamps {
             impl <NonInverting, Inverting, IntoOutput> IntoOpenLoop
                 <$opamp, NonInverting, Inverting, IntoOutput, $non_inverting, $inverting, $output> for Disabled<$opamp>
                 where
-                    NonInverting: FrozenPin<$non_inverting>,
-                    Inverting: FrozenPin<$inverting>,
+                    NonInverting: Frozen<$non_inverting>,
+                    Inverting: Frozen<$inverting>,
                     IntoOutput: Into<$output>,
             {
                 #[inline]
@@ -597,8 +597,8 @@ macro_rules! opamps {
             impl <NonInverting, Inverting> IntoOpenLoop
                 <$opamp, NonInverting, Inverting, InternalOutput, $non_inverting, $inverting, InternalOutput> for Disabled<$opamp>
                 where
-                    NonInverting: FrozenPin<$non_inverting>,
-                    Inverting: FrozenPin<$inverting>,
+                    NonInverting: Frozen<$non_inverting>,
+                    Inverting: Frozen<$inverting>,
             {
                 fn open_loop(
                     self,
@@ -698,16 +698,16 @@ macro_rules! opamps {
                     gain: Gain,
                 ) -> Pga<$opamp, $non_inverting, $output>
                 where
-                    IP: FrozenPin<$non_inverting>,
-                    OP: FrozenPin<$output>,
+                    IP: Frozen<$non_inverting>,
+                    OP: Frozen<$output>,
                 {
                     $opamp::configure_pga(gain, PgaMode::Pga, true)
                 }
 
                 #[allow(private_bounds)]
                 fn pga_external_filter<
-                    P1: FrozenPin<$non_inverting>,
-                    P2: FrozenPin<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
+                    P1: Frozen<$non_inverting>,
+                    P2: Frozen<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
                 >(
                     self,
                     _non_inverting: P1,
@@ -720,8 +720,8 @@ macro_rules! opamps {
 
                 #[allow(private_bounds)]
                 fn pga_external_bias<
-                    P1: FrozenPin<$non_inverting>,
-                    P2: FrozenPin<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
+                    P1: Frozen<$non_inverting>,
+                    P2: Frozen<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
                 >(
                     self,
                     _non_inverting: P1,
@@ -734,9 +734,9 @@ macro_rules! opamps {
 
                 #[allow(private_bounds)]
                 fn pga_external_bias_and_filter<
-                    P1: FrozenPin<$non_inverting>,
-                    P2: FrozenPin<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
-                    P3: FrozenPin<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm1>,
+                    P1: Frozen<$non_inverting>,
+                    P2: Frozen<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
+                    P3: Frozen<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm1>,
                 >(
                     self,
                     _non_inverting: P1,
@@ -758,16 +758,16 @@ macro_rules! opamps {
                     gain: Gain,
                 ) -> Pga<$opamp, $non_inverting, InternalOutput>
                 where
-                    IP: FrozenPin<$non_inverting>,
-                    OP: FrozenPin<InternalOutput>
+                    IP: Frozen<$non_inverting>,
+                    OP: Frozen<InternalOutput>
                 {
                     $opamp::configure_pga(gain, PgaMode::Pga, true)
                 }
 
                 #[allow(private_bounds)]
                 fn pga_external_filter<
-                    P1: FrozenPin<$non_inverting>,
-                    P2: FrozenPin<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
+                    P1: Frozen<$non_inverting>,
+                    P2: Frozen<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
                 >(
                     self,
                     _non_inverting: P1,
@@ -780,8 +780,8 @@ macro_rules! opamps {
 
                 #[allow(private_bounds)]
                 fn pga_external_bias<
-                    P1: FrozenPin<$non_inverting>,
-                    P2: FrozenPin<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
+                    P1: Frozen<$non_inverting>,
+                    P2: Frozen<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
                 >(
                     self,
                     _non_inverting: P1,
@@ -794,9 +794,9 @@ macro_rules! opamps {
 
                 #[allow(private_bounds)]
                 fn pga_external_bias_and_filter<
-                    P1: FrozenPin<$non_inverting>,
-                    P2: FrozenPin<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
-                    P3: FrozenPin<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm1>,
+                    P1: Frozen<$non_inverting>,
+                    P2: Frozen<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm0>,
+                    P3: Frozen<<$opamp as ConfigurePgaReg<$opamp, $non_inverting>>::Vinm1>,
                 >(
                     self,
                     _non_inverting: P1,

--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -59,10 +59,26 @@
 
 // TODO: Add support for calibration
 
-use crate::gpio::gpioa::{PA1, PA2, PA3, PA5, PA6, PA7, PA8};
-use crate::gpio::gpiob::{PB0, PB1, PB10, PB11, PB12, PB13, PB14, PB15, PB2};
-use crate::gpio::gpioc::{PC3, PC5};
-use crate::gpio::gpiod::{PD11, PD12, PD14, PD8, PD9};
+use crate::gpio::{
+    gpioa::{PA1, PA2, PA3, PA5, PA6, PA7},
+    gpiob::{PB0, PB1, PB10, PB13, PB14, PB2},
+    gpioc::PC5,
+    gpiod::PD14,
+};
+
+#[cfg(any(
+    feature = "stm32g473",
+    feature = "stm32g474",
+    feature = "stm32g483",
+    feature = "stm32g484",
+))]
+use crate::gpio::{
+    gpioa::PA8,
+    gpiob::{PB11, PB12, PB15},
+    gpioc::PC3,
+    gpiod::{PD11, PD12, PD8, PD9},
+};
+
 use crate::gpio::{Analog, FrozenPin, IsFrozen};
 use core::marker::PhantomData;
 
@@ -799,8 +815,6 @@ macro_rules! opamps {
 #[cfg(any(feature = "stm32g431", feature = "stm32g441", feature = "stm32g471",))]
 opamps! {
     Opamp1 => opamp1: {
-        vinm0: PA3<Analog, IsFrozen>,
-        vinm1: PC5<Analog, IsFrozen>,
         inverting: {
             vinm0: PA3<Analog, IsFrozen>,
             vinm1: PC5<Analog, IsFrozen>,
@@ -813,8 +827,6 @@ opamps! {
         output: PA2<Analog, IsFrozen>,
     },
     Opamp2 => opamp2: {
-        vinm0: PA5<Analog, IsFrozen>,
-        vinm1: PC5<Analog, IsFrozen>,
         inverting: {
             vinm0: PA5<Analog, IsFrozen>,
             vinm1: PC5<Analog, IsFrozen>,
@@ -828,8 +840,6 @@ opamps! {
         output: PA6<Analog, IsFrozen>,
     },
     Opamp3 => opamp3: {
-        vinm0: PB2<Analog, IsFrozen>,
-        vinm1: PB10<Analog, IsFrozen>,
         inverting: {
             vinm0: PB2<Analog, IsFrozen>,
             vinm1: PB10<Analog, IsFrozen>,

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -172,7 +172,7 @@
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
-use crate::gpio::FrozenPin;
+use crate::gpio::Frozen;
 use crate::gpio::IsFrozen;
 use crate::hal;
 use crate::stm32::LPTIMER1;
@@ -1116,7 +1116,7 @@ pub trait PwmExt: Sized {
     /// The requested frequency will be rounded to the nearest achievable frequency; the actual frequency may be higher or lower than requested.
     fn pwm<P, PINS, T, U, V>(self, _pins: P, frequency: T, rcc: &mut Rcc) -> PINS::Channel
     where
-        P: FrozenPin<PINS>,
+        P: Frozen<PINS>,
         PINS: Pins<Self, U, V>,
         T: Into<Hertz>;
 }
@@ -1128,7 +1128,7 @@ pub trait PwmAdvExt<WIDTH>: Sized {
         rcc: &mut Rcc,
     ) -> PwmBuilder<Self, PINS, CHANNEL, FaultDisabled, COMP, WIDTH>
     where
-        P: FrozenPin<PINS>,
+        P: Frozen<PINS>,
         PINS: Pins<Self, CHANNEL, COMP>;
 }
 
@@ -1138,7 +1138,7 @@ macro_rules! pwm_ext_hal {
         impl PwmExt for $TIMX {
             fn pwm<P, PINS, T, U, V>(self, pins: P, frequency: T, rcc: &mut Rcc) -> PINS::Channel
             where
-                P: FrozenPin<PINS>,
+                P: Frozen<PINS>,
                 PINS: Pins<Self, U, V>,
                 T: Into<Hertz>,
             {
@@ -1163,7 +1163,7 @@ macro_rules! tim_hal {
                 rcc: &mut Rcc,
             ) -> PINS::Channel
             where
-                P: FrozenPin<PINS>,
+                P: Frozen<PINS>,
                 PINS: Pins<$TIMX, T, U>,
             {
                 unsafe {
@@ -1206,7 +1206,7 @@ macro_rules! tim_hal {
                     rcc: &mut Rcc,
                 ) -> PwmBuilder<Self, PINS, CHANNEL, FaultDisabled, COMP, $typ>
                 where
-                    P: FrozenPin<PINS>,
+                    P: Frozen<PINS>,
                     PINS: Pins<Self, CHANNEL, COMP>
                 {
                     unsafe {
@@ -1783,7 +1783,7 @@ macro_rules! lptim_hal {
                 rcc: &mut Rcc,
             ) -> PINS::Channel
             where
-                P: FrozenPin<PINS>,
+                P: Frozen<PINS>,
                 PINS: Pins<$TIMX, T, U>,
             {
                 unsafe {

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -172,6 +172,8 @@
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
+use crate::gpio::FrozenPin;
+use crate::gpio::IsFrozen;
 use crate::hal;
 use crate::stm32::LPTIMER1;
 use crate::stm32::RCC;
@@ -219,7 +221,7 @@ use crate::gpio::{Alternate, AF1, AF10, AF11, AF12, AF2, AF3, AF4, AF5, AF6, AF9
 // This trait marks that a GPIO pin can be used with a specific timer channel
 // TIM is the timer being used
 // CHANNEL is a marker struct for the channel (or multi channels for tuples)
-// Example: impl Pins<TIM1, C1> for PA8<Alternate<AF1>> { type Channel = Pwm<TIM1, C1>; }
+// Example: impl Pins<TIM1, C1> for PA8<Alternate<AF1>, IsFrozen> { type Channel = Pwm<TIM1, C1>; }
 /// Pins is a trait that marks which GPIO pins may be used as PWM channels; it should not be directly used.
 /// See the device datasheet 'Pin descriptions' chapter for which pins can be used with which timer PWM channels (or look at Implementors)
 pub trait Pins<TIM, CHANNEL, COMP> {
@@ -550,27 +552,27 @@ macro_rules! pins {
 pins! {
     LPTIMER1:
         OUT: [
-            PA14<Alternate<AF1>>,
-            PB2<Alternate<AF1>>,
-            PC1<Alternate<AF1>>
+            PA14<Alternate<AF1>, IsFrozen>,
+            PB2<Alternate<AF1>, IsFrozen>,
+            PC1<Alternate<AF1>, IsFrozen>
         ]
 }
 // Dual channel timers
 pins! {
     TIM15:
         CH1(ComplementaryDisabled): [
-            PA2<Alternate<AF9>>,
-            PB14<Alternate<AF1>>,
-            PF9<Alternate<AF3>>
+            PA2<Alternate<AF9>, IsFrozen>,
+            PB14<Alternate<AF1>, IsFrozen>,
+            PF9<Alternate<AF3>, IsFrozen>
         ]
         CH2(ComplementaryImpossible): [
-            PA3<Alternate<AF9>>,
-            PB15<Alternate<AF1>>,
-            PF10<Alternate<AF3>>
+            PA3<Alternate<AF9>, IsFrozen>,
+            PB15<Alternate<AF1>, IsFrozen>,
+            PF10<Alternate<AF3>, IsFrozen>
         ]
         CH1N: [
-            PA1<Alternate<AF9>>,
-            PB15<Alternate<AF2>>,
+            PA1<Alternate<AF9>, IsFrozen>,
+            PB15<Alternate<AF2>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g471",
                 feature = "stm32g473",
@@ -578,47 +580,47 @@ pins! {
                 feature = "stm32g483",
                 feature = "stm32g484"
             ))]
-            PG9<Alternate<AF14>>
+            PG9<Alternate<AF14>, IsFrozen>
         ]
         CH2N: []
         BRK: [
-            PA9<Alternate<AF9>>,
-            PC5<Alternate<AF2>>
+            PA9<Alternate<AF9>, IsFrozen>,
+            PC5<Alternate<AF2>, IsFrozen>
         ]
         BRK2: []
     TIM16:
         CH1(ComplementaryDisabled): [
-            PA6<Alternate<AF1>>,
-            PA12<Alternate<AF1>>,
-            PB4<Alternate<AF1>>,
-            PB8<Alternate<AF1>>,
-            PE0<Alternate<AF4>>
+            PA6<Alternate<AF1>, IsFrozen>,
+            PA12<Alternate<AF1>, IsFrozen>,
+            PB4<Alternate<AF1>, IsFrozen>,
+            PB8<Alternate<AF1>, IsFrozen>,
+            PE0<Alternate<AF4>, IsFrozen>
         ]
         CH2(ComplementaryImpossible): []
         CH1N: [
-            PA13<Alternate<AF1>>,
-            PB6<Alternate<AF1>>
+            PA13<Alternate<AF1>, IsFrozen>,
+            PB6<Alternate<AF1>, IsFrozen>
         ]
         CH2N: []
         BRK: [
-            PB5<Alternate<AF1>>
+            PB5<Alternate<AF1>, IsFrozen>
         ]
         BRK2: []
     TIM17:
         CH1(ComplementaryDisabled): [
-            PA7<Alternate<AF1>>,
-            PB5<Alternate<AF10>>,
-            PB9<Alternate<AF1>>,
-            PE1<Alternate<AF4>>
+            PA7<Alternate<AF1>, IsFrozen>,
+            PB5<Alternate<AF10>, IsFrozen>,
+            PB9<Alternate<AF1>, IsFrozen>,
+            PE1<Alternate<AF4>, IsFrozen>
         ]
         CH2(ComplementaryImpossible): []
         CH1N: [
-            PB7<Alternate<AF1>>
+            PB7<Alternate<AF1>, IsFrozen>
         ]
         CH2N: []
         BRK: [
-            PA10<Alternate<AF1>>,
-            PB4<Alternate<AF10>>
+            PA10<Alternate<AF1>, IsFrozen>,
+            PB4<Alternate<AF10>, IsFrozen>
         ]
         BRK2: []
 }
@@ -626,87 +628,87 @@ pins! {
 pins! {
     TIM1:
         CH1(ComplementaryDisabled): [
-            PA8<Alternate<AF6>>,
-            PC0<Alternate<AF2>>,
-            PE9<Alternate<AF2>>
+            PA8<Alternate<AF6>, IsFrozen>,
+            PC0<Alternate<AF2>, IsFrozen>,
+            PE9<Alternate<AF2>, IsFrozen>
         ]
         CH2(ComplementaryDisabled): [
-            PA9<Alternate<AF6>>,
-            PC1<Alternate<AF2>>,
-            PE11<Alternate<AF2>>
+            PA9<Alternate<AF6>, IsFrozen>,
+            PC1<Alternate<AF2>, IsFrozen>,
+            PE11<Alternate<AF2>, IsFrozen>
         ]
         CH3(ComplementaryDisabled): [
-            PA10<Alternate<AF6>>,
-            PC2<Alternate<AF2>>,
-            PE13<Alternate<AF2>>
+            PA10<Alternate<AF6>, IsFrozen>,
+            PC2<Alternate<AF2>, IsFrozen>,
+            PE13<Alternate<AF2>, IsFrozen>
         ]
         CH4(ComplementaryDisabled): [
-            PA11<Alternate<AF11>>,
-            PC3<Alternate<AF2>>,
-            PE14<Alternate<AF2>>
+            PA11<Alternate<AF11>, IsFrozen>,
+            PC3<Alternate<AF2>, IsFrozen>,
+            PE14<Alternate<AF2>, IsFrozen>
         ]
         CH1N: [
-            PA7<Alternate<AF6>>,
-            PA11<Alternate<AF6>>,
-            PB13<Alternate<AF6>>,
-            PC13<Alternate<AF4>>,
-            PE8<Alternate<AF2>>
+            PA7<Alternate<AF6>, IsFrozen>,
+            PA11<Alternate<AF6>, IsFrozen>,
+            PB13<Alternate<AF6>, IsFrozen>,
+            PC13<Alternate<AF4>, IsFrozen>,
+            PE8<Alternate<AF2>, IsFrozen>
         ]
         CH2N: [
-            PA12<Alternate<AF6>>,
-            PB0<Alternate<AF6>>,
-            PB14<Alternate<AF6>>,
-            PE10<Alternate<AF2>>
+            PA12<Alternate<AF6>, IsFrozen>,
+            PB0<Alternate<AF6>, IsFrozen>,
+            PB14<Alternate<AF6>, IsFrozen>,
+            PE10<Alternate<AF2>, IsFrozen>
         ]
         CH3N: [
-            PB1<Alternate<AF6>>,
-            PB9<Alternate<AF12>>,
-            PB15<Alternate<AF4>>,
-            PE12<Alternate<AF2>>,
-            PF0<Alternate<AF6>>
+            PB1<Alternate<AF6>, IsFrozen>,
+            PB9<Alternate<AF12>, IsFrozen>,
+            PB15<Alternate<AF4>, IsFrozen>,
+            PE12<Alternate<AF2>, IsFrozen>,
+            PF0<Alternate<AF6>, IsFrozen>
         ]
         CH4N: [
-            PC5<Alternate<AF6>>,
-            PE15<Alternate<AF6>>
+            PC5<Alternate<AF6>, IsFrozen>,
+            PE15<Alternate<AF6>, IsFrozen>
         ]
         BRK: [
-            PA6<Alternate<AF6>>,
-            PA14<Alternate<AF6>>,
-            PA15<Alternate<AF9>>,
-            PB8<Alternate<AF12>>,
-            PB10<Alternate<AF12>>,
-            PB12<Alternate<AF6>>,
-            PC13<Alternate<AF2>>,
-            PE15<Alternate<AF2>>
+            PA6<Alternate<AF6>, IsFrozen>,
+            PA14<Alternate<AF6>, IsFrozen>,
+            PA15<Alternate<AF9>, IsFrozen>,
+            PB8<Alternate<AF12>, IsFrozen>,
+            PB10<Alternate<AF12>, IsFrozen>,
+            PB12<Alternate<AF6>, IsFrozen>,
+            PC13<Alternate<AF2>, IsFrozen>,
+            PE15<Alternate<AF2>, IsFrozen>
         ]
         BRK2: [
-            PA11<Alternate<AF12>>,
-            PC3<Alternate<AF6>>,
-            PE14<Alternate<AF6>>
+            PA11<Alternate<AF12>, IsFrozen>,
+            PC3<Alternate<AF6>, IsFrozen>,
+            PE14<Alternate<AF6>, IsFrozen>
         ]
     TIM2:
         CH1(ComplementaryImpossible): [
-            PA0<Alternate<AF1>>,
-            PA5<Alternate<AF1>>,
-            PA15<Alternate<AF1>>,
-            PD3<Alternate<AF2>>
+            PA0<Alternate<AF1>, IsFrozen>,
+            PA5<Alternate<AF1>, IsFrozen>,
+            PA15<Alternate<AF1>, IsFrozen>,
+            PD3<Alternate<AF2>, IsFrozen>
         ]
         CH2(ComplementaryImpossible): [
-            PA1<Alternate<AF1>>,
-            PB3<Alternate<AF1>>,
-            PD4<Alternate<AF2>>
+            PA1<Alternate<AF1>, IsFrozen>,
+            PB3<Alternate<AF1>, IsFrozen>,
+            PD4<Alternate<AF2>, IsFrozen>
         ]
         CH3(ComplementaryImpossible): [
-            PA2<Alternate<AF1>>,
-            PA9<Alternate<AF10>>,
-            PB10<Alternate<AF1>>,
-            PD7<Alternate<AF2>>
+            PA2<Alternate<AF1>, IsFrozen>,
+            PA9<Alternate<AF10>, IsFrozen>,
+            PB10<Alternate<AF1>, IsFrozen>,
+            PD7<Alternate<AF2>, IsFrozen>
         ]
         CH4(ComplementaryImpossible): [
-            PA3<Alternate<AF1>>,
-            PA10<Alternate<AF10>>,
-            PB11<Alternate<AF1>>,
-            PD6<Alternate<AF2>>
+            PA3<Alternate<AF1>, IsFrozen>,
+            PA10<Alternate<AF10>, IsFrozen>,
+            PB11<Alternate<AF1>, IsFrozen>,
+            PD6<Alternate<AF2>, IsFrozen>
         ]
         CH1N: []
         CH2N: []
@@ -716,28 +718,28 @@ pins! {
         BRK2: []
     TIM3:
         CH1(ComplementaryImpossible): [
-            PA6<Alternate<AF2>>,
-            PB4<Alternate<AF2>>,
-            PC6<Alternate<AF2>>,
-            PE2<Alternate<AF2>>
+            PA6<Alternate<AF2>, IsFrozen>,
+            PB4<Alternate<AF2>, IsFrozen>,
+            PC6<Alternate<AF2>, IsFrozen>,
+            PE2<Alternate<AF2>, IsFrozen>
         ]
         CH2(ComplementaryImpossible): [
-            PA4<Alternate<AF2>>,
-            PA7<Alternate<AF2>>,
-            PB5<Alternate<AF2>>,
-            PC7<Alternate<AF2>>,
-            PE3<Alternate<AF2>>
+            PA4<Alternate<AF2>, IsFrozen>,
+            PA7<Alternate<AF2>, IsFrozen>,
+            PB5<Alternate<AF2>, IsFrozen>,
+            PC7<Alternate<AF2>, IsFrozen>,
+            PE3<Alternate<AF2>, IsFrozen>
         ]
         CH3(ComplementaryImpossible): [
-            PB0<Alternate<AF2>>,
-            PC8<Alternate<AF2>>,
-            PE4<Alternate<AF2>>
+            PB0<Alternate<AF2>, IsFrozen>,
+            PC8<Alternate<AF2>, IsFrozen>,
+            PE4<Alternate<AF2>, IsFrozen>
         ]
         CH4(ComplementaryImpossible): [
-            PB1<Alternate<AF2>>,
-            PB7<Alternate<AF10>>,
-            PC9<Alternate<AF2>>,
-            PE5<Alternate<AF2>>
+            PB1<Alternate<AF2>, IsFrozen>,
+            PB7<Alternate<AF10>, IsFrozen>,
+            PC9<Alternate<AF2>, IsFrozen>,
+            PE5<Alternate<AF2>, IsFrozen>
         ]
         CH1N: []
         CH2N: []
@@ -747,23 +749,23 @@ pins! {
         BRK2: []
     TIM4:
         CH1(ComplementaryImpossible): [
-            PA11<Alternate<AF10>>,
-            PB6<Alternate<AF2>>,
-            PD12<Alternate<AF2>>
+            PA11<Alternate<AF10>, IsFrozen>,
+            PB6<Alternate<AF2>, IsFrozen>,
+            PD12<Alternate<AF2>, IsFrozen>
         ]
         CH2(ComplementaryImpossible): [
-            PA12<Alternate<AF10>>,
-            PB7<Alternate<AF2>>,
-            PD13<Alternate<AF2>>
+            PA12<Alternate<AF10>, IsFrozen>,
+            PB7<Alternate<AF2>, IsFrozen>,
+            PD13<Alternate<AF2>, IsFrozen>
         ]
         CH3(ComplementaryImpossible): [
-            PA13<Alternate<AF10>>,
-            PB8<Alternate<AF2>>,
-            PD14<Alternate<AF2>>
+            PA13<Alternate<AF10>, IsFrozen>,
+            PB8<Alternate<AF2>, IsFrozen>,
+            PD14<Alternate<AF2>, IsFrozen>
         ]
         CH4(ComplementaryImpossible): [
-            PB9<Alternate<AF2>>,
-            PD15<Alternate<AF2>>,
+            PB9<Alternate<AF2>, IsFrozen>,
+            PD15<Alternate<AF2>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g471",
                 feature = "stm32g473",
@@ -771,7 +773,7 @@ pins! {
                 feature = "stm32g483",
                 feature = "stm32g484"
             ))]
-            PF6<Alternate<AF2>>
+            PF6<Alternate<AF2>, IsFrozen>
         ]
         CH1N: []
         CH2N: []
@@ -790,24 +792,24 @@ pins! {
 pins! {
     TIM5:
         CH1(ComplementaryImpossible): [
-            PA0<Alternate<AF2>>,
-            PB2<Alternate<AF2>>,
-            PF6<Alternate<AF6>>
+            PA0<Alternate<AF2>, IsFrozen>,
+            PB2<Alternate<AF2>, IsFrozen>,
+            PF6<Alternate<AF6>, IsFrozen>
         ]
         CH2(ComplementaryImpossible): [
-            PA1<Alternate<AF2>>,
-            PC12<Alternate<AF1>>,
-            PF7<Alternate<AF6>>
+            PA1<Alternate<AF2>, IsFrozen>,
+            PC12<Alternate<AF1>, IsFrozen>,
+            PF7<Alternate<AF6>, IsFrozen>
         ]
         CH3(ComplementaryImpossible): [
-            PA2<Alternate<AF2>>,
-            PE8<Alternate<AF1>>,
-            PF8<Alternate<AF6>>
+            PA2<Alternate<AF2>, IsFrozen>,
+            PE8<Alternate<AF1>, IsFrozen>,
+            PF8<Alternate<AF6>, IsFrozen>
         ]
         CH4(ComplementaryImpossible): [
-            PA3<Alternate<AF2>>,
-            PE9<Alternate<AF1>>,
-            PF9<Alternate<AF6>>
+            PA3<Alternate<AF2>, IsFrozen>,
+            PE9<Alternate<AF1>, IsFrozen>,
+            PF9<Alternate<AF6>, IsFrozen>
         ]
         CH1N: []
         CH2N: []
@@ -819,53 +821,53 @@ pins! {
 pins! {
     TIM8:
         CH1(ComplementaryDisabled): [
-            PA15<Alternate<AF2>>,
-            PB6<Alternate<AF5>>,
-            PC6<Alternate<AF4>>
+            PA15<Alternate<AF2>, IsFrozen>,
+            PB6<Alternate<AF5>, IsFrozen>,
+            PC6<Alternate<AF4>, IsFrozen>
         ]
         CH2(ComplementaryDisabled): [
-            PA14<Alternate<AF5>>,
-            PB8<Alternate<AF10>>,
-            PC7<Alternate<AF4>>
+            PA14<Alternate<AF5>, IsFrozen>,
+            PB8<Alternate<AF10>, IsFrozen>,
+            PC7<Alternate<AF4>, IsFrozen>
         ]
         CH3(ComplementaryDisabled): [
-            PB9<Alternate<AF10>>,
-            PC8<Alternate<AF4>>
+            PB9<Alternate<AF10>, IsFrozen>,
+            PC8<Alternate<AF4>, IsFrozen>
         ]
         CH4(ComplementaryDisabled): [
-            PC9<Alternate<AF4>>,
-            PD1<Alternate<AF4>>
+            PC9<Alternate<AF4>, IsFrozen>,
+            PD1<Alternate<AF4>, IsFrozen>
         ]
         CH1N: [
-            PA7<Alternate<AF4>>,
-            PB3<Alternate<AF4>>,
-            PC10<Alternate<AF4>>
+            PA7<Alternate<AF4>, IsFrozen>,
+            PB3<Alternate<AF4>, IsFrozen>,
+            PC10<Alternate<AF4>, IsFrozen>
         ]
         CH2N: [
-            PB0<Alternate<AF4>>,
-            PB4<Alternate<AF4>>,
-            PC11<Alternate<AF4>>
+            PB0<Alternate<AF4>, IsFrozen>,
+            PB4<Alternate<AF4>, IsFrozen>,
+            PC11<Alternate<AF4>, IsFrozen>
         ]
         CH3N: [
-            PB1<Alternate<AF4>>,
-            PB5<Alternate<AF3>>,
-            PC12<Alternate<AF4>>
+            PB1<Alternate<AF4>, IsFrozen>,
+            PB5<Alternate<AF3>, IsFrozen>,
+            PC12<Alternate<AF4>, IsFrozen>
         ]
         CH4N: [
-            PC13<Alternate<AF6>>,
-            PD0<Alternate<AF6>>
+            PC13<Alternate<AF6>, IsFrozen>,
+            PD0<Alternate<AF6>, IsFrozen>
         ]
         BRK: [
-            PA0<Alternate<AF9>>,
-            PA6<Alternate<AF4>>,
-            PA10<Alternate<AF11>>,
-            PB7<Alternate<AF5>>,
-            PD2<Alternate<AF4>>
+            PA0<Alternate<AF9>, IsFrozen>,
+            PA6<Alternate<AF4>, IsFrozen>,
+            PA10<Alternate<AF11>, IsFrozen>,
+            PB7<Alternate<AF5>, IsFrozen>,
+            PD2<Alternate<AF4>, IsFrozen>
         ]
         BRK2: [
-            PB6<Alternate<AF10>>,
-            PC9<Alternate<AF6>>,
-            PD1<Alternate<AF6>>
+            PB6<Alternate<AF10>, IsFrozen>,
+            PC9<Alternate<AF6>, IsFrozen>,
+            PD1<Alternate<AF6>, IsFrozen>
         ]
 }
 #[cfg(any(
@@ -879,108 +881,108 @@ pins! {
 pins! {
     TIM20:
         CH1(ComplementaryDisabled): [
-            PB2<Alternate<AF3>>,
-            PE2<Alternate<AF6>>,
+            PB2<Alternate<AF3>, IsFrozen>,
+            PE2<Alternate<AF6>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF12<Alternate<AF2>>
+            PF12<Alternate<AF2>, IsFrozen>
         ]
         CH2(ComplementaryDisabled): [
-            PC2<Alternate<AF6>>,
-            PE3<Alternate<AF6>>,
+            PC2<Alternate<AF6>, IsFrozen>,
+            PE3<Alternate<AF6>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF13<Alternate<AF2>>
+            PF13<Alternate<AF2>, IsFrozen>
         ]
         CH3(ComplementaryDisabled): [
-            PC8<Alternate<AF6>>,
-            PF2<Alternate<AF2>>,
+            PC8<Alternate<AF6>, IsFrozen>,
+            PF2<Alternate<AF2>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF14<Alternate<AF2>>
+            PF14<Alternate<AF2>, IsFrozen>
         ]
         CH4(ComplementaryDisabled): [
-            PE1<Alternate<AF4>>,
+            PE1<Alternate<AF4>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF3<Alternate<AF2>>,
+            PF3<Alternate<AF2>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF15<Alternate<AF2>>
+            PF15<Alternate<AF2>, IsFrozen>
         ]
         CH1N: [
-            PE4<Alternate<AF6>>,
+            PE4<Alternate<AF6>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF4<Alternate<AF3>>,
+            PF4<Alternate<AF3>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PG0<Alternate<AF2>>
+            PG0<Alternate<AF2>, IsFrozen>
         ]
         CH2N: [
-            PE5<Alternate<AF6>>,
+            PE5<Alternate<AF6>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF5<Alternate<AF2>>,
+            PF5<Alternate<AF2>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PG1<Alternate<AF2>>
+            PG1<Alternate<AF2>, IsFrozen>
         ]
         CH3N: [
-            PE6<Alternate<AF6>>,
+            PE6<Alternate<AF6>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PG2<Alternate<AF2>>
+            PG2<Alternate<AF2>, IsFrozen>
         ]
         CH4N: [
-            PE0<Alternate<AF3>>,
+            PE0<Alternate<AF3>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PG3<Alternate<AF6>>
+            PG3<Alternate<AF6>, IsFrozen>
         ]
         BRK: [
             #[cfg(any(
@@ -989,22 +991,22 @@ pins! {
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF7<Alternate<AF2>>,
-            PF9<Alternate<AF2>>,
+            PF7<Alternate<AF2>, IsFrozen>,
+            PF9<Alternate<AF2>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PG3<Alternate<AF2>>,
+            PG3<Alternate<AF2>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PG6<Alternate<AF2>>
+            PG6<Alternate<AF2>, IsFrozen>
         ]
         BRK2: [
             #[cfg(any(
@@ -1013,15 +1015,15 @@ pins! {
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PF8<Alternate<AF2>>,
-            PF10<Alternate<AF2>>,
+            PF8<Alternate<AF2>, IsFrozen>,
+            PF10<Alternate<AF2>, IsFrozen>,
             #[cfg(any(
                 feature = "stm32g473",
                 feature = "stm32g474",
                 feature = "stm32g483",
                 feature = "stm32g484",
             ))]
-            PG4<Alternate<AF2>>
+            PG4<Alternate<AF2>, IsFrozen>
         ]
 }
 
@@ -1112,19 +1114,21 @@ fn calculate_deadtime(base_freq: Hertz, deadtime: NanoSecond) -> (u8, u8) {
 /// Allows the pwm() method to be added to the peripheral register structs from the device crate
 pub trait PwmExt: Sized {
     /// The requested frequency will be rounded to the nearest achievable frequency; the actual frequency may be higher or lower than requested.
-    fn pwm<PINS, T, U, V>(self, _pins: PINS, frequency: T, rcc: &mut Rcc) -> PINS::Channel
+    fn pwm<P, PINS, T, U, V>(self, _pins: P, frequency: T, rcc: &mut Rcc) -> PINS::Channel
     where
+        P: FrozenPin<PINS>,
         PINS: Pins<Self, U, V>,
         T: Into<Hertz>;
 }
 
 pub trait PwmAdvExt<WIDTH>: Sized {
-    fn pwm_advanced<PINS, CHANNEL, COMP>(
+    fn pwm_advanced<P, PINS, CHANNEL, COMP>(
         self,
-        _pins: PINS,
+        _pins: P,
         rcc: &mut Rcc,
     ) -> PwmBuilder<Self, PINS, CHANNEL, FaultDisabled, COMP, WIDTH>
     where
+        P: FrozenPin<PINS>,
         PINS: Pins<Self, CHANNEL, COMP>;
 }
 
@@ -1132,8 +1136,9 @@ pub trait PwmAdvExt<WIDTH>: Sized {
 macro_rules! pwm_ext_hal {
     ($TIMX:ident: $timX:ident) => {
         impl PwmExt for $TIMX {
-            fn pwm<PINS, T, U, V>(self, pins: PINS, frequency: T, rcc: &mut Rcc) -> PINS::Channel
+            fn pwm<P, PINS, T, U, V>(self, pins: P, frequency: T, rcc: &mut Rcc) -> PINS::Channel
             where
+                P: FrozenPin<PINS>,
                 PINS: Pins<Self, U, V>,
                 T: Into<Hertz>,
             {
@@ -1151,13 +1156,14 @@ macro_rules! tim_hal {
             pwm_ext_hal!($TIMX: $timX);
 
             /// Configures PWM
-            fn $timX<PINS, T, U>(
+            fn $timX<P, PINS, T, U>(
                 tim: $TIMX,
-                _pins: PINS,
+                _pins: P,
                 freq: Hertz,
                 rcc: &mut Rcc,
             ) -> PINS::Channel
             where
+                P: FrozenPin<PINS>,
                 PINS: Pins<$TIMX, T, U>,
             {
                 unsafe {
@@ -1194,12 +1200,13 @@ macro_rules! tim_hal {
             }
 
             impl PwmAdvExt<$typ> for $TIMX {
-                fn pwm_advanced<PINS, CHANNEL, COMP>(
+                fn pwm_advanced<P, PINS, CHANNEL, COMP>(
                     self,
-                    _pins: PINS,
+                    _pins: P,
                     rcc: &mut Rcc,
                 ) -> PwmBuilder<Self, PINS, CHANNEL, FaultDisabled, COMP, $typ>
                 where
+                    P: FrozenPin<PINS>,
                     PINS: Pins<Self, CHANNEL, COMP>
                 {
                     unsafe {
@@ -1769,13 +1776,14 @@ macro_rules! lptim_hal {
             pwm_ext_hal!($TIMX: $timX);
 
             /// Configures PWM signal on the LPTIM OUT pin.
-            fn $timX<PINS, T, U>(
+            fn $timX<P, PINS, T, U>(
                 tim: $TIMX,
-                _pins: PINS,
+                _pins: P,
                 freq: Hertz,
                 rcc: &mut Rcc,
             ) -> PINS::Channel
             where
+                P: FrozenPin<PINS>,
                 PINS: Pins<$TIMX, T, U>,
             {
                 unsafe {


### PR DESCRIPTION
### 1. Changing pin state
Today a gpio pin can be turned into another mode using for example `let pin = pin.into_push_pull_output();` or `let pin = pin.into_alternate()`. This can also be done multiple times for example:

```rust
let pin = pin.into_floating_input(); // Configure as digital input
//use as input...

let mut pin = pin.into_push_pull_output(); // Reconfigure the same pin, now as an output
pin.set_low();

let pin = pin.into_analog(); // Reconfigure as analog input
// perform AD-reading...
```

This is of course very convenient.

### 2. Same pin, Multiple peripherals

Some analog peripherals like for example the comparators need their input pins to be set in analog mode. Since the pin is set to analog mode it should also be possible to perform AD-readings on it at the same time as the comparator is connected.

This may for example be useful for having near instant over current protection while still allowing regular AD-readings all on the same pin.

### 3. Peripherals

When setting up a peripheral such as the comparator, the input pins are typically provided by value, thus consuming the pin. This to ensure that no one else will change the mode of the pin.

### The problem

Currently `1` and `3` works, but not `2`. Changing peripherals to take a pin by reference and store the reference would prove quite cumbersome since the pin would have to live as long as the peripheral and not be moved etc. 

Only having having the init function take a reference and then not storing it would not prevent the user from then changing pin mode after peripheral init.

### Proposed solution
Add type parameter `F` to the pin types which may be one of the following types:

```diff
- pub struct $PXi<MODE> {
+ pub struct $PXi<MODE, F = IsNotFrozen> {
     _mode: PhantomData<MODE>,
+    _frozen_state: PhantomData<F>,
 }

```rust
/// Type state for a gpio pin frozen to its current mode
/// 
/// The into_alternate/analog/{x}_input/output can not be called on a pin with this state.
/// The pin is thus guaranteed to stay as this type as long as the program is running.
pub struct IsFrozen;

/// See [IsFrozen]
pub struct IsNotFrozen;
```
The type parameter default to `IsNotFrozen` so as to keep backwards compatibility and `1` from above works as before. However once the user knows they will want the pin to stay in a particular state for the rest of the program, `let pin = pin.freeze();` may be called. Which returns the same type but with `IsFrozen` this disabling the `into_alternate/analog/{x}_input/output` methods.

This then allows peripherals init to take the pin by reference (assuming `F=IsFrozen`) and not having to hold on to it. (only done for some of the peripherals so far)