### PR TITLE
Fix `listen` return mode and relax pin constraint

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -475,7 +475,7 @@ macro_rules! gpio {
                     }
 
                     /// Configures the pin as external trigger
-                    pub fn listen(self, edge: SignalEdge, exti: &mut EXTI) -> $PXi<Input<Mode>> {
+                    pub fn listen(self, edge: SignalEdge, exti: &mut EXTI) -> $PXi<Input<MODE>> {
                         exti.listen(Event::from_code($i), edge);
                         $PXi { _mode: PhantomData }
                     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -475,7 +475,7 @@ macro_rules! gpio {
                     }
 
                     /// Configures the pin as external trigger
-                    pub fn listen(self, edge: SignalEdge, exti: &mut EXTI) -> $PXi<Input<MODE>> {
+                    pub fn listen(self, edge: SignalEdge, exti: &mut EXTI) -> $PXi<MODE> {
                         exti.listen(Event::from_code($i), edge);
                         $PXi { _mode: PhantomData }
                     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -475,17 +475,7 @@ macro_rules! gpio {
                     }
 
                     /// Configures the pin as external trigger
-                    pub fn listen(self, edge: SignalEdge, exti: &mut EXTI) -> $PXi<Input<PushPull>> {
-                        let offset = 2 * $i;
-                        unsafe {
-                            let gpio = &(*$GPIOX::ptr());
-                            gpio.pupdr.modify(|r, w| {
-                                w.bits(r.bits() & !(0b11 << offset))
-                            });
-                            gpio.moder.modify(|r, w| {
-                                w.bits(r.bits() & !(0b11 << offset))
-                            })
-                        };
+                    pub fn listen(self, edge: SignalEdge, exti: &mut EXTI) -> $PXi<Input<Mode>> {
                         exti.listen(Event::from_code($i), edge);
                         $PXi { _mode: PhantomData }
                     }


### PR DESCRIPTION
The `listen` function for GPIO pins had a return type of `P<Input<PushPull>>` which to my understanding is a nonsensical pin mode.

Additionally, the body of the function forced the pin to be a floating input, but EXTI works with pins in any mode, so the original mode should persist.