### PR TITLE
Fix warnings introduced with rust 1.82

### DIFF
--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -122,8 +122,7 @@ fn main() -> ! {
     block!(can.transmit(header, &buffer)).unwrap();
 
     loop {
-        if let Ok(rxheader) = block!(can.receive0(&mut buffer)) {
-            block!(can.transmit(rxheader.unwrap().to_tx_header(None), &buffer)).unwrap();
-        }
+        let Ok(rxheader) = block!(can.receive0(&mut buffer));
+        block!(can.transmit(rxheader.unwrap().to_tx_header(None), &buffer)).unwrap();
     }
 }

--- a/examples/can-echo.rs
+++ b/examples/can-echo.rs
@@ -122,7 +122,9 @@ fn main() -> ! {
     block!(can.transmit(header, &buffer)).unwrap();
 
     loop {
-        let Ok(rxheader) = block!(can.receive0(&mut buffer));
-        block!(can.transmit(rxheader.unwrap().to_tx_header(None), &buffer)).unwrap();
+        #[allow(irrefutable_let_patterns)]
+        if let Ok(rxheader) = block!(can.receive0(&mut buffer)) {
+            block!(can.transmit(rxheader.unwrap().to_tx_header(None), &buffer)).unwrap();
+        }
     }
 }


### PR DESCRIPTION
This fixes the warnings about irrefutable `if let` patterns introduced in rustc 1.82. However the fix as implemented in 9b27404 more or less raises the effective MSRV to 1.82...

We don't really have a MSRV as far as I know but perhaps 9b27404 should wait a while.