### PR TITLE
Allow selecting any clock source when freezing rcc configuration

### DIFF
--- a/src/can.rs
+++ b/src/can.rs
@@ -11,19 +11,6 @@ mod sealed {
     pub trait Rx<CAN> {}
 }
 
-/// Select an FDCAN Clock Source
-#[allow(clippy::upper_case_acronyms)]
-#[allow(dead_code)]
-enum FdCanClockSource {
-    /// Select HSE as the FDCAN clock source
-    HSE = 0b00,
-    /// Select PLL "Q" clock as the FDCAN clock source
-    PLLQ = 0b01,
-    /// Select "P" clock as the FDCAN clock source
-    PCLK = 0b10,
-    //Reserved = 0b10,
-}
-
 /// Storage type for the CAN controller
 #[derive(Debug)]
 pub struct Can<FDCAN> {
@@ -54,18 +41,6 @@ where
         RX: sealed::Rx<Self>,
     {
         Self::enable(&rcc.rb);
-
-        if rcc.rb.ccipr.read().fdcansel().is_hse() {
-            // Select P clock as FDCAN clock source
-            rcc.rb.ccipr.modify(|_, w| {
-                // This is sound, as `FdCanClockSource` only contains valid values for this field.
-                unsafe {
-                    w.fdcansel().bits(FdCanClockSource::PCLK as u8);
-                }
-
-                w
-            });
-        }
 
         self.fdcan_unchecked()
     }

--- a/src/rcc/config.rs
+++ b/src/rcc/config.rs
@@ -325,6 +325,18 @@ impl Default for PllConfig {
     }
 }
 
+/// FDCAN Clock Source
+#[allow(clippy::upper_case_acronyms)]
+pub enum FdCanClockSource {
+    /// Select HSE as the FDCAN clock source
+    HSE = 0b00,
+    /// Select PLL "Q" clock as the FDCAN clock source
+    PLLQ = 0b01,
+    /// Select "P" clock as the FDCAN clock source
+    PCLK = 0b10,
+    //Reserved = 0b10,
+}
+
 /// Clocks configutation
 pub struct Config {
     pub(crate) sys_mux: SysClockSrc,
@@ -335,6 +347,8 @@ pub struct Config {
 
     /// Required for f_sys > 150MHz
     pub(crate) enable_boost: bool,
+
+    pub(crate) fdcansel: FdCanClockSource,
 }
 
 impl Config {
@@ -379,6 +393,11 @@ impl Config {
         self.enable_boost = enable_boost;
         self
     }
+
+    pub fn fdcan_src(mut self, mux: FdCanClockSource) -> Self {
+        self.fdcansel = mux;
+        self
+    }
 }
 
 impl Default for Config {
@@ -390,6 +409,7 @@ impl Default for Config {
             apb1_psc: Prescaler::NotDivided,
             apb2_psc: Prescaler::NotDivided,
             enable_boost: false,
+            fdcansel: FdCanClockSource::HSE,
         }
     }
 }

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -216,6 +216,12 @@ impl Rcc {
             _ => apb2_freq * 2,
         };
 
+        // Configure FDCAN clock source.
+        self.rb.ccipr.modify(|_, w| unsafe {
+            // This is sound, as `FdCanClockSource` only contains valid values for this field.
+            w.fdcansel().bits(rcc_cfg.fdcansel as u8)
+        });
+
         Rcc {
             rb: self.rb,
             clocks: Clocks {


### PR DESCRIPTION
Currently PCLK is is statically configured when the constructor for the FDCAN peripheral is called. This pull request adds selecting the clock source.

This also means the default clock source is HSE (the reset value) rather than PCLK. The `can-echo` example doesn't need to be updated as it assumes PCLK = HSE.