### PR TITLE
Simplify DMA impl removing most macros

### DIFF
--- a/src/dma/channel.rs
+++ b/src/dma/channel.rs
@@ -346,7 +346,7 @@ impl<I: Instance, const N: u8> Channel for C<I, N> {
     fn get_half_transfer_flag(&self) -> bool {
         //NOTE(unsafe) Atomic read with no side effects
         let dma = unsafe { &*I::ptr() };
-        dma.isr().read().htif(N as u8).bit_is_set()
+        dma.isr().read().htif(N).bit_is_set()
     }
 
     #[inline(always)]
@@ -354,7 +354,7 @@ impl<I: Instance, const N: u8> Channel for C<I, N> {
         //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
         // that belongs to the ChannelX
         let dma = unsafe { &*I::ptr() };
-        dma.ifcr().write(|w| w.chtif(N as u8).set_bit());
+        dma.ifcr().write(|w| w.chtif(N).set_bit());
         let _ = dma.isr().read();
         let _ = dma.isr().read(); // Delay 2 peripheral clocks
     }
@@ -446,7 +446,7 @@ impl<I: Instance, const N: u8> C<I, N> {
         //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
         // that belongs to the ChannelX
         let dma = unsafe { &*I::ptr() };
-        dma.ifcr().write(|w| w.chtif(N as u8).set_bit());
+        dma.ifcr().write(|w| w.chtif(N).set_bit());
         let _ = dma.isr().read();
         let _ = dma.isr().read(); // Delay 2 peripheral clocks
     }
@@ -455,7 +455,7 @@ impl<I: Instance, const N: u8> C<I, N> {
     pub fn get_half_transfer_flag() -> bool {
         //NOTE(unsafe) Atomic read with no side effects
         let dma = unsafe { &*I::ptr() };
-        dma.isr().read().htif(N as u8).bit_is_set()
+        dma.isr().read().htif(N).bit_is_set()
     }
 
     #[inline(always)]

--- a/src/dma/channel.rs
+++ b/src/dma/channel.rs
@@ -72,16 +72,16 @@ pub struct DmaInterrupts {
 
 /// Alias for a tuple with all DMA channels.
 pub struct Channels<T> {
-    pub ch1: Channel1<T>,
-    pub ch2: Channel2<T>,
-    pub ch3: Channel3<T>,
-    pub ch4: Channel4<T>,
-    pub ch5: Channel5<T>,
-    pub ch6: Channel6<T>,
+    pub ch1: C<T, 0>,
+    pub ch2: C<T, 1>,
+    pub ch3: C<T, 2>,
+    pub ch4: C<T, 3>,
+    pub ch5: C<T, 4>,
+    pub ch6: C<T, 5>,
     #[cfg(not(any(feature = "stm32g431", feature = "stm32g441",)))]
-    pub ch7: Channel7<T>,
+    pub ch7: C<T, 6>,
     #[cfg(not(any(feature = "stm32g431", feature = "stm32g441",)))]
-    pub ch8: Channel8<T>,
+    pub ch8: C<T, 7>,
 }
 
 pub trait DMAExt<I> {
@@ -122,376 +122,348 @@ impl<I: Instance> Channels<I> {
     /// Splits the DMA peripheral into channels.
     pub(crate) fn new(_regs: I) -> Self {
         Self {
-            ch1: Channel1 { _dma: PhantomData },
-            ch2: Channel2 { _dma: PhantomData },
-            ch3: Channel3 { _dma: PhantomData },
-            ch4: Channel4 { _dma: PhantomData },
-            ch5: Channel5 { _dma: PhantomData },
-            ch6: Channel6 { _dma: PhantomData },
+            ch1: C { _dma: PhantomData },
+            ch2: C { _dma: PhantomData },
+            ch3: C { _dma: PhantomData },
+            ch4: C { _dma: PhantomData },
+            ch5: C { _dma: PhantomData },
+            ch6: C { _dma: PhantomData },
             #[cfg(not(any(feature = "stm32g431", feature = "stm32g441",)))]
-            ch7: Channel7 { _dma: PhantomData },
+            ch7: C { _dma: PhantomData },
             #[cfg(not(any(feature = "stm32g431", feature = "stm32g441",)))]
-            ch8: Channel8 { _dma: PhantomData },
+            ch8: C { _dma: PhantomData },
         }
     }
 }
 
-// Macro that creates a struct representing a channel on either DMA controller
-//
-// The implementation does the heavy lifting of mapping to the right fields on
-// the channel
-macro_rules! dma_channel {
-    ($(($name:ident, $number:expr)),+$(,)*) => {
-        $(
-            /// Channel $number on DMA
-            pub struct $name<DMA> {
-                _dma: PhantomData<DMA>,
-            }
-
-            impl<DMA> Sealed for $name<DMA> {}
-
-            impl<I: Instance> Channel for $name<I> {
-
-                const NUMBER: usize = $number - 1;
-                type Config = DmaConfig;
-                type Interrupts = DmaInterrupts;
-
-                fn apply_config(&mut self, config: DmaConfig) {
-                    self.set_priority(config.priority);
-                    self.set_memory_increment(config.memory_increment);
-                    self.set_peripheral_increment(config.peripheral_increment);
-                    self.set_circular_buffer(config.circular_buffer);
-                    self.set_transfer_complete_interrupt_enable(
-                        config.transfer_complete_interrupt
-                    );
-                    self.set_half_transfer_interrupt_enable(config.half_transfer_interrupt);
-                    self.set_transfer_error_interrupt_enable(
-                        config.transfer_error_interrupt
-                    );
-                }
-
-                #[inline(always)]
-                fn clear_interrupts(&mut self) {
-                    let num = Self::NUMBER as u8;
-
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the ChannelX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr().write(|w| w
-                        .ctcif(num).set_bit() //Clear transfer complete interrupt flag
-                        .chtif(num).set_bit() //Clear half transfer interrupt flag
-                        .cteif(num).set_bit() //Clear transfer error interrupt flag
-                        .cgif(num).set_bit() //Clear global interrupt flag
-                    );
-                    let _ = dma.isr().read();
-                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn clear_transfer_complete_flag(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the ChannelX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr().write(|w| w.ctcif(Self::NUMBER as u8).set_bit());
-                }
-
-                #[inline(always)]
-                fn clear_transfer_complete_interrupt(&mut self) {
-                    self.clear_transfer_complete_flag();
-                    //NOTE(unsafe) Atomic read with no side-effects.
-                    let dma = unsafe { &*I::ptr() };
-                    let _ = dma.isr().read();
-                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn clear_transfer_error_interrupt(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the ChannelX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr().write(|w| w.ctcif(Self::NUMBER as u8).set_bit());
-                    let _ = dma.isr().read();
-                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn get_transfer_complete_flag() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma = unsafe { &*I::ptr() };
-                    dma.isr().read().tcif(Self::NUMBER as u8).bit_is_set()
-                }
-
-                #[inline(always)]
-                fn get_transfer_error_flag() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma = unsafe { &*I::ptr() };
-                    dma.isr().read().tcif(Self::NUMBER as u8).bit_is_set()
-                }
-
-                #[inline(always)]
-                unsafe fn enable(&mut self) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| w.en().set_bit());
-                }
-
-                #[inline(always)]
-                fn is_enabled() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().read().en().bit_is_set()
-                }
-
-                fn disable(&mut self) {
-                    if Self::is_enabled() {
-                        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                        let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
-
-                        // Aborting an on-going transfer might cause interrupts to fire, disable
-                        // them
-                        let interrupts = Self::get_interrupts_enable();
-                        self.disable_interrupts();
-
-                        dma_ch.cr().modify(|_, w| w.en().clear_bit());
-                        while Self::is_enabled() {}
-
-                        self.clear_interrupts();
-                        self.enable_interrupts(interrupts);
-                    }
-                }
-
-                #[inline(always)]
-                fn set_request_line(&mut self, request_line: u8) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dmamux = unsafe { &*I::mux_ptr() };
-                    unsafe {
-                        dmamux.ccr($number)
-                            .modify(|_, w| w.dmareq_id().bits(request_line));
-                    }
-                }
-
-                #[inline(always)]
-                fn set_priority(&mut self, priority: config::Priority) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| unsafe { w.pl().bits(priority.bits()) });
-                }
-
-                #[inline(always)]
-                fn disable_interrupts(&mut self) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
-                    dmacr.modify(|_, w| w
-                        .tcie().clear_bit()
-                        .teie().clear_bit()
-                        .htie().clear_bit());
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn enable_interrupts(&mut self, interrupt: Self::Interrupts) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = &unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| w
-                        .tcie().bit(interrupt.transfer_complete)
-                        .teie().bit(interrupt.transfer_error)
-                        .htie().bit(interrupt.half_transfer)
-                    );
-                }
-
-                #[inline(always)]
-                fn get_interrupts_enable() -> Self::Interrupts {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    let cr = dma_ch.cr().read();
-
-                    DmaInterrupts {
-                        transfer_complete: cr.tcie().bit_is_set(),
-                        half_transfer: cr.htie().bit_is_set(),
-                        transfer_error: cr.teie().bit_is_set()
-                    }
-                }
-
-
-                #[inline(always)]
-                fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
-                    dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn set_transfer_error_interrupt_enable(&mut self, transfer_error_interrupt: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
-                    dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
-                    dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                fn get_half_transfer_flag() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma = unsafe { &*I::ptr() };
-                    dma.isr().read().htif(Self::NUMBER as u8).bit_is_set()
-                }
-
-                #[inline(always)]
-                fn clear_half_transfer_interrupt(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the ChannelX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr().write(|w| w.chtif(Self::NUMBER as u8).set_bit());
-                    let _ = dma.isr().read();
-                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                unsafe fn set_peripheral_address(&mut self, value: u32) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.par().write(|w| w.pa().bits(value));
-                }
-
-                #[inline(always)]
-                unsafe fn set_memory_address(&mut self, value: u32) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.mar().write(|w| w.ma().bits(value) );
-                }
-
-                #[inline(always)]
-                fn get_memory_address(&self) -> u32 {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.mar().read().ma().bits()
-                }
-
-                #[inline(always)]
-                fn set_number_of_transfers(&mut self, value: u16) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.ndtr().write(|w| unsafe {w.ndt().bits(value) });
-                }
-
-                #[inline(always)]
-                fn get_number_of_transfers() -> u16 {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.ndtr().read().ndt().bits()
-                }
-                #[inline(always)]
-                unsafe fn set_memory_size(&mut self, size: u8) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| w.msize().bits(size));
-                }
-
-                #[inline(always)]
-                unsafe fn set_peripheral_size(&mut self, size: u8) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| w.psize().bits(size));
-                }
-
-                #[inline(always)]
-                fn set_memory_increment(&mut self, increment: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| w.minc().bit(increment));
-                }
-
-                #[inline(always)]
-                fn set_peripheral_increment(&mut self, increment: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| w.pinc().bit(increment));
-                }
-
-                #[inline(always)]
-                fn set_direction(&mut self, direction: DmaDirection) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| {
-                        match direction {
-                            DmaDirection::PeripheralToMemory =>
-                                w.dir().clear_bit().mem2mem().clear_bit(),
-                            DmaDirection::MemoryToPeripheral =>
-                                w.dir().set_bit().mem2mem().clear_bit(),
-                            DmaDirection::MemoryToMemory =>
-                                w.mem2mem().set_bit().dir().clear_bit(),
-                        }
-                    });
-                }
-
-                #[inline(always)]
-                fn set_circular_buffer(&mut self, circular_buffer: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dma_ch = unsafe { &*I::ptr() }.ch(Self::NUMBER);
-                    dma_ch.cr().modify(|_, w| w.circ().bit(circular_buffer));
-                }
-            }
-
-            impl<I: Instance> $name<I> {
-                #[inline(always)]
-                pub fn clear_half_transfer_interrupt(&mut self) {
-                    //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
-                    // that belongs to the ChannelX
-                    let dma = unsafe { &*I::ptr() };
-                    dma.ifcr().write(|w| w.chtif(Self::NUMBER as u8).set_bit());
-                    let _ = dma.isr().read();
-                    let _ = dma.isr().read(); // Delay 2 peripheral clocks
-                }
-
-                #[inline(always)]
-                pub fn get_half_transfer_flag() -> bool {
-                    //NOTE(unsafe) Atomic read with no side effects
-                    let dma = unsafe { &*I::ptr() };
-                    dma.isr().read().htif(Self::NUMBER as u8).bit_is_set()
-                }
-
-                #[inline(always)]
-                pub fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
-                    //NOTE(unsafe) We only access the registers that belongs to the ChannelX
-                    let dmacr = &unsafe { &*I::ptr() }.ch(Self::NUMBER).cr();
-                    dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
-                    let _ = dmacr.read();
-                    let _ = dmacr.read(); // Delay 2 peripheral clocks
-                }
-            }
-        )+
-    };
+/// Channel on DMA
+///
+/// Note that `C<DMA, 0>` here maps to Channel1
+pub struct C<DMA, const N: u8> {
+    _dma: PhantomData<DMA>,
 }
 
-dma_channel!(
-    (Channel1, 1),
-    (Channel2, 2),
-    (Channel3, 3),
-    (Channel4, 4),
-    (Channel5, 5),
-    (Channel6, 6),
-);
+impl<I: Instance, const N: u8> Sealed for C<I, N> {}
 
-// Cat 3 and 4 devices
-#[cfg(any(
-    feature = "stm32g471",
-    feature = "stm32g473",
-    feature = "stm32g474",
-    feature = "stm32g483",
-    feature = "stm32g484",
-    feature = "stm32g491",
-    feature = "stm32g4a1",
-))]
-dma_channel!((Channel7, 7), (Channel8, 8),);
+impl<I: Instance, const N: u8> C<I, N> {
+    fn ch(&self) -> &stm32::dma1::CH {
+        // NOTE(unsafe) grants access only to this channels registers
+        unsafe { &*I::ptr() }.ch(N as usize)
+    }
+}
+
+impl<I: Instance, const N: u8> Channel for C<I, N> {
+    type Interrupts = DmaInterrupts;
+
+    fn apply_config(&mut self, config: DmaConfig) {
+        self.set_priority(config.priority);
+        self.set_memory_increment(config.memory_increment);
+        self.set_peripheral_increment(config.peripheral_increment);
+        self.set_circular_buffer(config.circular_buffer);
+        self.set_transfer_complete_interrupt_enable(config.transfer_complete_interrupt);
+        self.set_half_transfer_interrupt_enable(config.half_transfer_interrupt);
+        self.set_transfer_error_interrupt_enable(config.transfer_error_interrupt);
+    }
+
+    #[inline(always)]
+    fn clear_interrupts(&mut self) {
+        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+        // that belongs to the ChannelX
+        let dma = unsafe { &*I::ptr() };
+        dma.ifcr().write(
+            |w| {
+                w.ctcif(N)
+                    .set_bit() //Clear transfer complete interrupt flag
+                    .chtif(N)
+                    .set_bit() //Clear half transfer interrupt flag
+                    .cteif(N)
+                    .set_bit() //Clear transfer error interrupt flag
+                    .cgif(N)
+                    .set_bit()
+            }, //Clear global interrupt flag
+        );
+        let _ = dma.isr().read();
+        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    fn clear_transfer_complete_flag(&mut self) {
+        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+        // that belongs to the ChannelX
+        let dma = unsafe { &*I::ptr() };
+        dma.ifcr().write(|w| w.ctcif(N).set_bit());
+    }
+
+    #[inline(always)]
+    fn clear_transfer_complete_interrupt(&mut self) {
+        self.clear_transfer_complete_flag();
+        //NOTE(unsafe) Atomic read with no side-effects.
+        let dma = unsafe { &*I::ptr() };
+        let _ = dma.isr().read();
+        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    fn clear_transfer_error_interrupt(&mut self) {
+        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+        // that belongs to the ChannelX
+        let dma = unsafe { &*I::ptr() };
+        dma.ifcr().write(|w| w.ctcif(N).set_bit());
+        let _ = dma.isr().read();
+        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    fn get_transfer_complete_flag(&self) -> bool {
+        //NOTE(unsafe) Atomic read with no side effects
+        let dma = unsafe { &*I::ptr() };
+        dma.isr().read().tcif(N).bit_is_set()
+    }
+
+    #[inline(always)]
+    fn get_transfer_error_flag(&self) -> bool {
+        //NOTE(unsafe) Atomic read with no side effects
+        let dma = unsafe { &*I::ptr() };
+        dma.isr().read().tcif(N).bit_is_set()
+    }
+
+    #[inline(always)]
+    unsafe fn enable(&mut self) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = &unsafe { &*I::ptr() }.ch(N as usize);
+        dma_ch.cr().modify(|_, w| w.en().set_bit());
+    }
+
+    #[inline(always)]
+    fn is_enabled(&self) -> bool {
+        //NOTE(unsafe) Atomic read with no side effects
+        let dma_ch = &unsafe { &*I::ptr() }.ch(N as usize);
+        dma_ch.cr().read().en().bit_is_set()
+    }
+
+    fn disable(&mut self) {
+        if self.is_enabled() {
+            //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+            let dma_ch = &unsafe { &*I::ptr() }.ch(N as usize);
+
+            // Aborting an on-going transfer might cause interrupts to fire, disable
+            // them
+            let interrupts = self.get_interrupts_enable();
+            self.disable_interrupts();
+
+            dma_ch.cr().modify(|_, w| w.en().clear_bit());
+            while self.is_enabled() {}
+
+            self.clear_interrupts();
+            self.enable_interrupts(interrupts);
+        }
+    }
+
+    #[inline(always)]
+    fn set_request_line(&mut self, request_line: u8) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dmamux = unsafe { &*I::mux_ptr() };
+        unsafe {
+            dmamux
+                .ccr(N as usize)
+                .modify(|_, w| w.dmareq_id().bits(request_line));
+        }
+    }
+
+    #[inline(always)]
+    fn set_priority(&mut self, priority: config::Priority) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = &self.ch();
+        dma_ch
+            .cr()
+            .modify(|_, w| unsafe { w.pl().bits(priority.bits()) });
+    }
+
+    #[inline(always)]
+    fn disable_interrupts(&mut self) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dmacr = &self.ch().cr();
+        dmacr.modify(|_, w| w.tcie().clear_bit().teie().clear_bit().htie().clear_bit());
+        let _ = dmacr.read();
+        let _ = dmacr.read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    fn enable_interrupts(&mut self, interrupt: Self::Interrupts) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = &self.ch();
+        dma_ch.cr().modify(|_, w| {
+            w.tcie()
+                .bit(interrupt.transfer_complete)
+                .teie()
+                .bit(interrupt.transfer_error)
+                .htie()
+                .bit(interrupt.half_transfer)
+        });
+    }
+
+    #[inline(always)]
+    fn get_interrupts_enable(&self) -> Self::Interrupts {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        let cr = dma_ch.cr().read();
+
+        DmaInterrupts {
+            transfer_complete: cr.tcie().bit_is_set(),
+            half_transfer: cr.htie().bit_is_set(),
+            transfer_error: cr.teie().bit_is_set(),
+        }
+    }
+
+    #[inline(always)]
+    fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dmacr = &self.ch().cr();
+        dmacr.modify(|_, w| w.tcie().bit(transfer_complete_interrupt));
+        let _ = dmacr.read();
+        let _ = dmacr.read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    fn set_transfer_error_interrupt_enable(&mut self, transfer_error_interrupt: bool) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dmacr = &self.ch().cr();
+        dmacr.modify(|_, w| w.teie().bit(transfer_error_interrupt));
+        let _ = dmacr.read();
+        let _ = dmacr.read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dmacr = &self.ch().cr();
+        dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+        let _ = dmacr.read();
+        let _ = dmacr.read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    fn get_half_transfer_flag(&self) -> bool {
+        //NOTE(unsafe) Atomic read with no side effects
+        let dma = unsafe { &*I::ptr() };
+        dma.isr().read().htif(N as u8).bit_is_set()
+    }
+
+    #[inline(always)]
+    fn clear_half_transfer_interrupt(&mut self) {
+        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+        // that belongs to the ChannelX
+        let dma = unsafe { &*I::ptr() };
+        dma.ifcr().write(|w| w.chtif(N as u8).set_bit());
+        let _ = dma.isr().read();
+        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    unsafe fn set_peripheral_address(&mut self, value: u32) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.par().write(|w| w.pa().bits(value));
+    }
+
+    #[inline(always)]
+    unsafe fn set_memory_address(&mut self, value: u32) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.mar().write(|w| w.ma().bits(value));
+    }
+
+    #[inline(always)]
+    fn get_memory_address(&self) -> u32 {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.mar().read().ma().bits()
+    }
+
+    #[inline(always)]
+    fn set_number_of_transfers(&mut self, value: u16) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.ndtr().write(|w| unsafe { w.ndt().bits(value) });
+    }
+
+    #[inline(always)]
+    fn get_number_of_transfers(&self) -> u16 {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.ndtr().read().ndt().bits()
+    }
+    #[inline(always)]
+    unsafe fn set_memory_size(&mut self, size: u8) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.cr().modify(|_, w| w.msize().bits(size));
+    }
+
+    #[inline(always)]
+    unsafe fn set_peripheral_size(&mut self, size: u8) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.cr().modify(|_, w| w.psize().bits(size));
+    }
+
+    #[inline(always)]
+    fn set_memory_increment(&mut self, increment: bool) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.cr().modify(|_, w| w.minc().bit(increment));
+    }
+
+    #[inline(always)]
+    fn set_peripheral_increment(&mut self, increment: bool) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.cr().modify(|_, w| w.pinc().bit(increment));
+    }
+
+    #[inline(always)]
+    fn set_direction(&mut self, direction: DmaDirection) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.cr().modify(|_, w| match direction {
+            DmaDirection::PeripheralToMemory => w.dir().clear_bit().mem2mem().clear_bit(),
+            DmaDirection::MemoryToPeripheral => w.dir().set_bit().mem2mem().clear_bit(),
+            DmaDirection::MemoryToMemory => w.mem2mem().set_bit().dir().clear_bit(),
+        });
+    }
+
+    #[inline(always)]
+    fn set_circular_buffer(&mut self, circular_buffer: bool) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dma_ch = self.ch();
+        dma_ch.cr().modify(|_, w| w.circ().bit(circular_buffer));
+    }
+}
+
+impl<I: Instance, const N: u8> C<I, N> {
+    #[inline(always)]
+    pub fn clear_half_transfer_interrupt(&mut self) {
+        //NOTE(unsafe) Atomic write with no side-effects and we only access the bits
+        // that belongs to the ChannelX
+        let dma = unsafe { &*I::ptr() };
+        dma.ifcr().write(|w| w.chtif(N as u8).set_bit());
+        let _ = dma.isr().read();
+        let _ = dma.isr().read(); // Delay 2 peripheral clocks
+    }
+
+    #[inline(always)]
+    pub fn get_half_transfer_flag() -> bool {
+        //NOTE(unsafe) Atomic read with no side effects
+        let dma = unsafe { &*I::ptr() };
+        dma.isr().read().htif(N as u8).bit_is_set()
+    }
+
+    #[inline(always)]
+    pub fn set_half_transfer_interrupt_enable(&mut self, half_transfer_interrupt: bool) {
+        //NOTE(unsafe) We only access the registers that belongs to the ChannelX
+        let dmacr = &self.ch().cr();
+        dmacr.modify(|_, w| w.htie().bit(half_transfer_interrupt));
+        let _ = dmacr.read();
+        let _ = dmacr.read(); // Delay 2 peripheral clocks
+    }
+}

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -13,21 +13,16 @@ pub(crate) mod sealed {
     }
     pub trait Sealed {}
 }
+use config::DmaConfig;
 use sealed::Sealed;
 
 /// Minimal trait for DMA channels
 pub trait Channel: Sealed {
-    /// Number of the channel register
-    const NUMBER: usize;
-
-    /// Configuration structure for this channel.
-    type Config;
-
     /// Structure representing interrupts
     type Interrupts: Copy + Debug;
 
     /// Apply the configation structure to this channel.
-    fn apply_config(&mut self, config: Self::Config);
+    fn apply_config(&mut self, config: DmaConfig);
 
     /// Clear all interrupts for the DMA channel.
     fn clear_interrupts(&mut self);
@@ -45,10 +40,10 @@ pub trait Channel: Sealed {
     fn clear_transfer_error_interrupt(&mut self);
 
     /// Get transfer complete flag.
-    fn get_transfer_complete_flag() -> bool;
+    fn get_transfer_complete_flag(&self) -> bool;
 
     /// Get transfer error flag.
-    fn get_transfer_error_flag() -> bool;
+    fn get_transfer_error_flag(&self) -> bool;
 
     /// Enable the DMA channel.
     ///
@@ -58,7 +53,7 @@ pub trait Channel: Sealed {
     unsafe fn enable(&mut self);
 
     /// Returns the state of the DMA channel.
-    fn is_enabled() -> bool;
+    fn is_enabled(&self) -> bool;
 
     /// Disable the DMA channel.
     ///
@@ -81,7 +76,7 @@ pub trait Channel: Sealed {
     fn enable_interrupts(&mut self, interrupts: Self::Interrupts);
 
     /// Get the value of all the interrupts for this DMA channel
-    fn get_interrupts_enable() -> Self::Interrupts;
+    fn get_interrupts_enable(&self) -> Self::Interrupts;
 
     /// Enable/disable the transfer complete interrupt (tcie) of the DMA channel.
     fn set_transfer_complete_interrupt_enable(&mut self, transfer_complete_interrupt: bool);
@@ -110,7 +105,7 @@ pub trait Channel: Sealed {
     fn clear_half_transfer_interrupt(&mut self);
 
     /// Get half transfer flag.
-    fn get_half_transfer_flag() -> bool;
+    fn get_half_transfer_flag(&self) -> bool;
 
     /// Get the memory address for the DMA channel.
     fn get_memory_address(&self) -> u32;
@@ -125,7 +120,7 @@ pub trait Channel: Sealed {
     fn set_number_of_transfers(&mut self, value: u16);
 
     /// Get the number of transfers (ndt) for the DMA channel.
-    fn get_number_of_transfers() -> u16;
+    fn get_number_of_transfers(&self) -> u16;
 
     /// Set the memory size (msize) for the DMA channel.
     ///


### PR DESCRIPTION
Simplify DMA impl by not using macros now that the pac has been improved using the same pac types across the two DMAs