### PR TITLE
defmt Format for RCC Clocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ paste = "1.0"
 bitflags = "1.2"
 vcell = "0.1"
 static_assertions = "1.1"
-fugit = "0.3.5"
+fugit = "0.3.7"
 stm32-usbd = { version = "0.7.0", optional = true }
 fixed = { version = "1.28.0", optional = true }
 
@@ -93,7 +93,7 @@ stm32g4a1 = ["stm32g4/stm32g4a1"]
 log-itm = ["cortex-m-log/itm"]
 log-rtt = []
 log-semihost = ["cortex-m-log/semihosting"]
-defmt-logging = ["defmt"]
+defmt = ["dep:defmt", "fugit/defmt"]
 cordic = ["dep:fixed"]
 
 [profile.dev]

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -16,6 +16,7 @@ pub const HSI_FREQ: u32 = 16_000_000;
 
 /// Clock frequencies
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Clocks {
     /// System frequency
     pub sys_clk: Hertz,
@@ -37,6 +38,7 @@ pub struct Clocks {
 
 /// PLL Clock frequencies
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PLLClocks {
     /// R frequency
     pub r: Option<Hertz>,


### PR DESCRIPTION
Some initial `Format` derives for RCC clocks, really lots of structures should derive `Format`.

I also bumped `fugit`.

The idiomatic `defmt` feature across lots of crates seems to be the name "defmt" itself, so I also changed the `defmt-logging` feature to just `defmt`.