### PR TITLE
Export PwrExt In Prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -43,3 +43,4 @@ pub use crate::pwm::PwmExt as _;
 // pub use crate::timer::TimerExt as _;
 // pub use crate::watchdog::IWDGExt as _;
 // pub use crate::watchdog::WWDGExt as _;
+pub use crate::pwr::PwrExt as _;


### PR DESCRIPTION
I noticed the `PwrExt` re-export was missing from `prelude`.

On a side note, why are so many exports commented out? Is this a regression that slipped by?