### PR TITLE
[TRACKING] Derive `defmt::Format`

### DIFF
--- a/src/dma.rs
+++ b/src/dma.rs
@@ -28,6 +28,7 @@ pub use transfer::{Transfer, TransferExt};
 
 /// Errors.
 #[derive(PartialEq, Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DMAError {
     /// DMA not ready to change buffers.
     NotReady,
@@ -39,6 +40,7 @@ pub enum DMAError {
 
 /// Possible DMA's directions.
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DmaDirection {
     /// Memory to Memory transfer.
     MemoryToMemory,
@@ -50,6 +52,7 @@ pub enum DmaDirection {
 
 /// DMA from a peripheral to a memory location.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PeripheralToMemory;
 
 impl PeripheralToMemory {
@@ -73,6 +76,7 @@ impl Direction for PeripheralToMemory {
 
 /// DMA from one memory location to another memory location.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MemoryToMemory<T>
 where
     T: Into<u32>,
@@ -101,6 +105,7 @@ where
 
 /// DMA from a memory location to a peripheral.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MemoryToPeripheral;
 
 impl MemoryToPeripheral {

--- a/src/dma/transfer.rs
+++ b/src/dma/transfer.rs
@@ -12,11 +12,14 @@ use core::{
 use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
 
 /// Marker type for a transfer with a mutable source and backed by a
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct MutTransfer;
 /// Marker type for a transfer with a constant source and backed by a
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct ConstTransfer;
 
 /// DMA Transfer.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Transfer<CHANNEL, PERIPHERAL, DIR, BUF, TXFRT>
 where
     CHANNEL: Channel,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -18,34 +18,43 @@ pub trait GpioExt {
 }
 
 /// Input mode (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Input<MODE> {
     _mode: PhantomData<MODE>,
 }
 
 /// Floating input (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Floating;
 
 /// Pulled down input (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PullDown;
 
 /// Pulled up input (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PullUp;
 
 /// Open drain input or output (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OpenDrain;
 
 /// Analog mode (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Analog;
 
 /// Output mode (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Output<MODE> {
     _mode: PhantomData<MODE>,
 }
 
 /// Push pull output (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PushPull;
 
 /// GPIO Pin speed selection
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Speed {
     Low = 0,
     Medium = 1,
@@ -54,6 +63,7 @@ pub enum Speed {
 }
 
 /// Trigger edgw
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum SignalEdge {
     Rising,
     Falling,
@@ -61,7 +71,9 @@ pub enum SignalEdge {
 }
 
 /// Altername Mode (type state)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Alternate<const A: u8>;
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AlternateOD<const A: u8>;
 
 pub const AF0: u8 = 0;
@@ -267,6 +279,7 @@ macro_rules! gpio {
             }
 
             /// Partially erased pin
+            #[cfg_attr(feature = "defmt", derive(defmt::Format))]
             pub struct $PXx<MODE> {
                 i: u8,
                 _mode: PhantomData<MODE>,
@@ -338,6 +351,7 @@ macro_rules! gpio {
             exti_erased!($PXx<Input<MODE>>, $Pxn);
 
             $(
+                #[cfg_attr(feature = "defmt", derive(defmt::Format))]
                 pub struct $PXi<MODE> {
                     _mode: PhantomData<MODE>,
                 }

--- a/src/serial/config.rs
+++ b/src/serial/config.rs
@@ -232,6 +232,7 @@ impl FullConfig {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InvalidConfig;
 
 impl Default for LowPowerConfig {

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -16,6 +16,7 @@ use nb::block;
 use crate::serial::config::*;
 /// Serial error
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// Framing error
     Framing,
@@ -28,6 +29,7 @@ pub enum Error {
 }
 
 /// Interrupt event
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Event {
     /// TXFIFO reaches the threshold
     TXFT = 1 << 27,
@@ -74,6 +76,7 @@ impl Event {
 }
 
 /// Serial receiver
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Rx<USART, Pin, Dma> {
     pin: Pin,
     _usart: PhantomData<USART>,
@@ -81,6 +84,7 @@ pub struct Rx<USART, Pin, Dma> {
 }
 
 /// Serial transmitter
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Tx<USART, Pin, Dma> {
     pin: Pin,
     usart: USART,
@@ -88,6 +92,7 @@ pub struct Tx<USART, Pin, Dma> {
 }
 
 /// Serial abstraction
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Serial<USART, TXPin, RXPin> {
     tx: Tx<USART, TXPin, NoDMA>,
     rx: Rx<USART, RXPin, NoDMA>,
@@ -99,15 +104,18 @@ pub trait TxPin<USART> {}
 /// Serial RX pin
 pub trait RxPin<USART> {}
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NoTx;
 
 impl<USART> TxPin<USART> for NoTx {}
 
 /// Type state for Tx/Rx, indicating operation without DMA
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct NoDMA;
 /// Type state for Tx/Rx, indicating configuration for DMA
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct DMA;
 
 pub trait SerialExt<USART, Config> {


### PR DESCRIPTION
This PR tracks the addition of `defmt::Format` derives on various HAL structures.