### PR TITLE
Add Tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,13 @@ codegen-units = 1
 incremental = false
 lto = true
 
+[profile.test]
+opt-level = "s"
+debug = true
+codegen-units = 1
+incremental = false
+lto = true
+
 [[example]]
 name = "flash_with_rtic"
 required-features = ["stm32g474"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ name = "cordic"
 required-features = ["cordic"]
 
 [[test]]
-name = "pwm"
+name = "tests"
 harness = false
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ optional = true
 [dev-dependencies]
 cortex-m-rt = "0.7.2"
 defmt-rtt = "0.4.0"
+defmt-test = "0.3.2"
 cortex-m-rtic = "1.1.4"
 cortex-m-semihosting = "0.3.5"
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
@@ -130,3 +131,10 @@ required-features = ["usb"]
 [[example]]
 name = "cordic"
 required-features = ["cordic"]
+
+[[test]]
+name = "pwm"
+harness = false
+
+[lib]
+test = false

--- a/examples/utils/logger.rs
+++ b/examples/utils/logger.rs
@@ -1,6 +1,6 @@
 #![allow(unsafe_code)]
 cfg_if::cfg_if! {
-    if #[cfg(all(feature = "log-rtt", feature = "defmt"))] {
+    if #[cfg(feature = "defmt")] {
         #[allow(unused_imports)]
         pub use defmt::{info, trace, warn, debug, error};
 
@@ -55,7 +55,7 @@ cfg_if::cfg_if! {
         }
 
     }
-    else if #[cfg(all(feature = "log-rtt"/*, feature = "defmt"*/))] {
+    else if #[cfg(feature = "defmt")] {
         use defmt_rtt as _; // global logger
         use panic_probe as _;
         #[allow(unused_imports)]
@@ -65,9 +65,6 @@ cfg_if::cfg_if! {
 
         #[allow(dead_code)]
         pub fn init() {}
-    }
-    else if #[cfg(all(feature = "log-rtt", not(feature = "defmt")))] {
-        // TODO
     }
     else if #[cfg(feature = "log-semihost")] {
         use panic_semihosting as _;

--- a/tests/pwm.rs
+++ b/tests/pwm.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-#[path ="../examples/utils/mod.rs"]
+#[path = "../examples/utils/mod.rs"]
 mod utils;
 
 use utils::logger::println;
@@ -15,68 +15,144 @@ use stm32g4xx_hal as hal;
 
 #[defmt_test::tests]
 mod tests {
-    use embedded_hal::pwm::SetDutyCycle;
+    use embedded_hal::{
+        digital::{InputPin, OutputPin},
+        pwm::SetDutyCycle,
+    };
     use fugit::RateExtU32;
     use stm32g4xx_hal::{
-        delay::SYSTDelayExt, gpio::{GpioExt, AF6}, pwm::PwmExt, rcc::RccExt, stm32::GPIOA,
+        delay::SYSTDelayExt,
+        gpio::{GpioExt, AF6},
+        pwm::PwmExt,
+        rcc::RccExt,
+        stm32::GPIOA,
     };
+
+    #[test]
+    fn gpio_push_pull() {
+        use super::*;
+
+        // TODO: Is it ok to steal these?
+        let cp = unsafe { stm32::CorePeripherals::steal() };
+        let dp = unsafe { stm32::Peripherals::steal() };
+        let mut rcc = dp.RCC.constrain();
+        let mut delay = cp.SYST.delay(&rcc.clocks);
+
+        let gpioa = dp.GPIOA.split(&mut rcc);
+        let mut pin = gpioa.pa8.into_push_pull_output();
+
+        pin.set_high().unwrap();
+        delay.delay(1.millis()); // Give the pin plenty of time to go high
+        assert!(pin.is_high().unwrap());
+        {
+            let gpioa = unsafe { &*GPIOA::PTR };
+            assert!(!is_pa8_low(gpioa));
+        }
+
+        pin.set_low().unwrap();
+        delay.delay(1.millis()); // Give the pin plenty of time to go low
+        assert!(pin.is_low().unwrap());
+        {
+            let gpioa = unsafe { &*GPIOA::PTR };
+            assert!(is_pa8_low(gpioa));
+        }
+    }
+
+    #[test]
+    fn gpio_open_drain() {
+        use super::*;
+
+        // TODO: Is it ok to steal these?
+        let cp = unsafe { stm32::CorePeripherals::steal() };
+        let dp = unsafe { stm32::Peripherals::steal() };
+        let mut rcc = dp.RCC.constrain();
+        let mut delay = cp.SYST.delay(&rcc.clocks);
+
+        let gpioa = dp.GPIOA.split(&mut rcc);
+        let mut pin = gpioa.pa8.into_open_drain_output();
+
+        // Enable pull-up resistor
+        {
+            let gpioa = unsafe { &*GPIOA::PTR };
+            gpioa.pupdr().modify(|_, w| w.pupdr8().pull_up());
+        }
+
+        pin.set_high().unwrap();
+        delay.delay(1.millis()); // Give the pin plenty of time to go high
+        assert!(pin.is_high().unwrap());
+        {
+            let gpioa = unsafe { &*GPIOA::PTR };
+            assert!(!is_pa8_low(gpioa));
+        }
+
+        pin.set_low().unwrap();
+        delay.delay(1.millis()); // Give the pin plenty of time to go low
+        assert!(pin.is_low().unwrap());
+        {
+            let gpioa = unsafe { &*GPIOA::PTR };
+            assert!(is_pa8_low(gpioa));
+        }
+    }
 
     #[test]
     fn foo() {
         use super::*;
 
-        let cp = stm32::CorePeripherals::take().expect("cannot take peripherals");
-        let dp = stm32::Peripherals::take().expect("cannot take peripherals");
+        // TODO: Is it ok to steal these?
+        let cp = unsafe { stm32::CorePeripherals::steal() };
+        let dp = unsafe { stm32::Peripherals::steal() };
         let mut rcc = dp.RCC.constrain();
         let mut delay = cp.SYST.delay(&rcc.clocks);
 
         let gpioa = dp.GPIOA.split(&mut rcc);
-        let pin: stm32g4xx_hal::gpio::gpioa::PA8<stm32g4xx_hal::gpio::Alternate<AF6>> = gpioa.pa8.into_alternate();
+        let pin: stm32g4xx_hal::gpio::gpioa::PA8<stm32g4xx_hal::gpio::Alternate<AF6>> =
+            gpioa.pa8.into_alternate();
 
-        //let mut pwm = dp.TIM1.pwm(pin, 1000u32.Hz(), &mut rcc);
+        let mut pwm = dp.TIM1.pwm(pin, 1000u32.Hz(), &mut rcc);
 
-        //pwm.set_duty_cycle_percent(50).unwrap();
-        //pwm.enable();
-        
+        pwm.set_duty_cycle_percent(50).unwrap();
+        pwm.enable();
 
         let gpioa = unsafe { &*GPIOA::PTR };
 
-        let get_pin_state = || unsafe {  (0x4800_0004 as *const u32).read_volatile() };
+        //let get_pin_state = || unsafe {  (0x4800_0004 as *const u32).read_volatile() };
 
         // TODO: This is a very bad way to measure time
-        let min: MicrosDurationU32 = 490u32.micros();// Some extra on min for cpu overhead
+        let min: MicrosDurationU32 = 490u32.micros(); // Some extra on min for cpu overhead
         let max: MicrosDurationU32 = 505u32.micros();
 
         {
             println!("Awaiting first rising edge...");
-            //println!("{}", gpioa.odr().read().odr(8).is_high());
-            println!("{}", get_pin_state());
-            //let duration_until_lo = await_lo(&gpioa, &mut delay, max);//.unwrap();
-        }
-        /*
-            //println!("Low..., Waited ~{}us until low", duration_until_lo);
-            let lo_duration = await_hi(&gpioa, &mut delay, max);//.unwrap();
-            //println!("High..., Low half period: {}us", lo_duration);
+            let duration_until_lo = await_lo(&gpioa, &mut delay, max).unwrap();
+            println!("Low..., Waited ~{} until low", duration_until_lo);
+            let lo_duration = await_hi(&gpioa, &mut delay, max).unwrap();
+            println!("High..., Low half period: {}", lo_duration);
         }
 
         for _ in 0..10 {
             // Make sure the timer half periods are within 490-505us
 
-            let hi_duration = await_lo(&gpioa, &mut delay, max);//.unwrap();
-            println!("Low..., High half period: {}us", hi_duration);
-            //assert!(hi_duration > min, "{} > {}", hi_duration, min);
+            let hi_duration = await_lo(&gpioa, &mut delay, max).unwrap();
+            println!("Low..., High half period: {}", hi_duration);
+            assert!(hi_duration > min, "{} > {}", hi_duration, min);
 
-            let lo_duration = await_hi(&gpioa, &mut delay, max);//.unwrap();
-            println!("High..., Low half period: {}us", lo_duration);
-            //assert!(lo_duration > min, "{} > {}", lo_duration, min);
+            let lo_duration = await_hi(&gpioa, &mut delay, max).unwrap();
+            println!("High..., Low half period: {}", lo_duration);
+            assert!(lo_duration > min, "{} > {}", lo_duration, min);
         }
 
         println!("Done!");
         for i in (0..5).rev() {
             println!("{}", i);
             delay.delay(1000.millis());
-        }*/
+        }
+
+        pwm.disable();
     }
+}
+
+fn is_pa8_low(gpioa: &stm32::gpioa::RegisterBlock) -> bool {
+    gpioa.idr().read().idr(8).is_low()
 }
 
 #[derive(Debug, defmt::Format)]
@@ -87,7 +163,7 @@ fn await_lo(
     delay: &mut SystDelay,
     timeout: MicrosDurationU32,
 ) -> Result<MicrosDurationU32, ErrorTimedOut> {
-    await_p(|| gpioa.idr().read().idr(8).is_low(), delay, timeout)
+    await_p(|| is_pa8_low(gpioa), delay, timeout)
 }
 
 fn await_hi(
@@ -95,7 +171,7 @@ fn await_hi(
     delay: &mut SystDelay,
     timeout: MicrosDurationU32,
 ) -> Result<MicrosDurationU32, ErrorTimedOut> {
-    await_p(|| gpioa.idr().read().idr(8).is_high(), delay, timeout)
+    await_p(|| !is_pa8_low(gpioa), delay, timeout)
 }
 
 fn await_p(
@@ -107,7 +183,7 @@ fn await_p(
         if p() {
             return Ok(i.micros());
         }
-        //delay.delay(1_u32.micros());
+        delay.delay(1_u32.micros());
     }
     Err(ErrorTimedOut)
 }

--- a/tests/pwm.rs
+++ b/tests/pwm.rs
@@ -1,0 +1,93 @@
+#![no_std]
+#![no_main]
+
+#[path ="../examples/utils/mod.rs"]
+mod utils;
+
+use utils::logger::println;
+
+use core::ops::FnMut;
+use core::result::Result;
+use fugit::{ExtU32, MicrosDurationU32};
+use hal::delay::{DelayExt, SystDelay};
+use hal::stm32;
+use stm32g4xx_hal as hal;
+
+#[defmt_test::tests]
+mod tests {
+    use embedded_hal::pwm::SetDutyCycle;
+    use fugit::RateExtU32;
+    use stm32g4xx_hal::{
+        delay::SYSTDelayExt, gpio::GpioExt, pwm::PwmExt, rcc::RccExt, stm32::GPIOA,
+    };
+
+    #[test]
+    fn foo() {
+        use super::*;
+
+        let cp = stm32::CorePeripherals::take().expect("cannot take peripherals");
+        let dp = stm32::Peripherals::take().expect("cannot take peripherals");
+        let mut rcc = dp.RCC.constrain();
+        let mut delay = cp.SYST.delay(&rcc.clocks);
+
+        let gpioa = dp.GPIOA.split(&mut rcc);
+        let pin = gpioa.pa8.into_alternate();
+
+        let mut pwm = dp.TIM1.pwm(pin, 1000u32.Hz(), &mut rcc);
+
+        let _ = pwm.set_duty_cycle_percent(50);
+        pwm.enable();
+
+        let gpioa = unsafe { &*GPIOA::ptr() };
+
+        let min: MicrosDurationU32 = 490u32.micros();// Some extra on min for cpu overhead
+        let max: MicrosDurationU32 = 505u32.micros();
+
+        println!("Awaiting rising edge...");
+        await_lo(&gpioa, &mut delay, max).unwrap();
+        await_hi(&gpioa, &mut delay, max).unwrap();
+
+        for _ in 0..10 {
+            // Make sure the timer half periods are within 490-505us
+
+            let hi_duration = await_lo(&gpioa, &mut delay, max).unwrap();
+            let lo_duration = await_hi(&gpioa, &mut delay, max).unwrap();
+
+            assert!(hi_duration > min);
+            assert!(lo_duration > min);
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ErrorTimedOut;
+
+fn await_lo(
+    gpioa: &stm32::gpioa::RegisterBlock,
+    delay: &mut SystDelay,
+    timeout: MicrosDurationU32,
+) -> Result<MicrosDurationU32, ErrorTimedOut> {
+    await_p(|| gpioa.idr().read().idr(8).is_low(), delay, timeout)
+}
+
+fn await_hi(
+    gpioa: &stm32::gpioa::RegisterBlock,
+    delay: &mut SystDelay,
+    timeout: MicrosDurationU32,
+) -> Result<MicrosDurationU32, ErrorTimedOut> {
+    await_p(|| gpioa.idr().read().idr(8).is_high(), delay, timeout)
+}
+
+fn await_p(
+    mut p: impl FnMut() -> bool,
+    delay: &mut SystDelay,
+    timeout: MicrosDurationU32,
+) -> Result<MicrosDurationU32, ErrorTimedOut> {
+    for i in 0..timeout.ticks() {
+        if p() {
+            return Ok(i.micros());
+        }
+        delay.delay(1_u32.micros());
+    }
+    Err(ErrorTimedOut)
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -95,7 +95,7 @@ mod tests {
     }
 
     #[test]
-    fn foo() {
+    fn pwm() {
         use super::*;
 
         // TODO: Is it ok to steal these?

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -261,7 +261,7 @@ mod tests {
         debug!("temp: {}°C", temp);
         assert!((20.0..30.0).contains(&temp), "20.0 < {} < 30.0", temp);
     }
-    
+
     #[test]
     fn dac() {
         use super::*;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -261,8 +261,7 @@ mod tests {
         debug!("temp: {}°C", temp);
         assert!((20.0..30.0).contains(&temp), "20.0 < {} < 30.0", temp);
     }
-
-    // TODO: This does not seem to work
+    
     #[test]
     fn dac() {
         use super::*;
@@ -274,7 +273,8 @@ mod tests {
         let mut delay = cp.SYST.delay(&rcc.clocks);
 
         let gpioa = dp.GPIOA.split(&mut rcc);
-        let dac1ch1 = dp.DAC1.constrain(gpioa.pa4, &mut rcc);
+        let pa4 = gpioa.pa4.into_floating_input();
+        let dac1ch1 = dp.DAC1.constrain(pa4, &mut rcc);
 
         let gpioa = unsafe { &*GPIOA::PTR };
 
@@ -282,18 +282,12 @@ mod tests {
         let mut dac = dac1ch1.calibrate_buffer(&mut delay).enable();
 
         dac.set_value(0);
-        delay.delay_ms(100);
+        delay.delay_ms(1);
         assert!(is_pax_low(&gpioa, 4));
 
-        /*for i in (0..=4095).step_by(10) {
-            dac.set_value(i);
-            delay.delay_ms(1);
-            defmt::println!("i: {}, is_pax_low: {}", i, gpioa.idr().read().bits());
-        }
-
-        delay.delay_ms(100);
-        assert!(!is_pax_low(&gpioa, 4)); // TODO: <---- Why does this not work?
-        */
+        dac.set_value(4095);
+        delay.delay_ms(1);
+        assert!(!is_pax_low(&gpioa, 4));
     }
 }
 


### PR DESCRIPTION
Thought I would try to experiment a bit with adding tests that could run an a Nucleo or similar without any ~~/with very little~~ external connections.

From what I can tell the input registers are supposed to be usable even after the pin has been put into alternate mode. So in my mind I should for example be able to verify that the PWM is working by measuring the time on and time off.
