### PR TITLE
BUG - Not working in release mode

### DIFF
--- a/examples/broken.rs
+++ b/examples/broken.rs
@@ -1,0 +1,29 @@
+//This example puts the timer in PWM mode using the specified pin with a frequency of 100Hz and a duty cycle of 50%.
+#![no_main]
+#![no_std]
+
+use cortex_m_rt::entry;
+use utils::logger::println;
+use hal::gpio::AF6;
+use hal::prelude::*;
+use hal::stm32;
+use stm32g4xx_hal as hal;
+extern crate cortex_m_rt as rt;
+
+#[macro_use]
+mod utils;
+
+#[entry]
+fn main() -> ! {
+    let dp = stm32::Peripherals::take().expect("cannot take peripherals");
+    let mut rcc = dp.RCC.constrain();
+
+    let gpioa = dp.GPIOA.split(&mut rcc);
+    let _pin: stm32g4xx_hal::gpio::gpioa::PA8<stm32g4xx_hal::gpio::Alternate<AF6>> =
+        gpioa.pa8.into_alternate();
+    let mut pin2 = gpioa.pa9.into_pull_up_input();
+    defmt::println!("hej");
+    pin2.is_high().unwrap(); // <--- Booom
+
+    loop {}
+}


### PR DESCRIPTION
This short example does not work in release mode:

```rust
#[entry]
fn main() -> ! {
    let dp = stm32::Peripherals::take().expect("cannot take peripherals");
    let mut rcc = dp.RCC.constrain();

    let gpioa = dp.GPIOA.split(&mut rcc);
    let _pin: stm32g4xx_hal::gpio::gpioa::PA8<stm32g4xx_hal::gpio::Alternate<AF6>> =
        gpioa.pa8.into_alternate();
    let mut pin2 = gpioa.pa9.into_pull_up_input();
    defmt::println!("hej");
    pin2.is_high().unwrap(); // <--- Booom

    loop {}
}
```

```
DEFMT_LOG=trace cargo r --example broken --features stm32g474,defmt,log-rtt -- --chip stm32g474RETx
warning: unused import: `utils::logger::println`
 --> examples/broken.rs:6:5
  |
6 | use utils::logger::println;
  |     ^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `stm32g4xx-hal` (example "broken") generated 1 warning (run `cargo fix --example "broken"` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.37s
     Running `probe-rs run --connect-under-reset --chip=stm32g474RETx target/thumbv7em-none-eabihf/debug/examples/broken`
      Erasing ✔ 100% [####################]  20.00 KiB @  58.10 KiB/s (took 0s)
  Programming ✔ 100% [####################]  19.00 KiB @  42.07 KiB/s (took 0s)                                                                                      Finished in 0.80s
hej
```

```
DEFMT_LOG=trace cargo r --example broken --features stm32g474,defmt,log-rtt --release  -- --chip stm32g474RETx
warning: unused import: `utils::logger::println`
 --> examples/broken.rs:6:5
  |
6 | use utils::logger::println;
  |     ^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `stm32g4xx-hal` (example "broken") generated 1 warning (run `cargo fix --example "broken"` to apply 1 suggestion)
    Finished `release` profile [optimized] target(s) in 0.21s
     Running `probe-rs run --connect-under-reset --chip=stm32g474RETx target/thumbv7em-none-eabihf/release/examples/broken`
 WARN probe_rs::util::rtt: Insufficient DWARF info; compile your program with `debug = 2` to enable location info.
      Erasing ✔ 100% [####################]   8.00 KiB @  51.94 KiB/s (took 0s)
  Programming ✔ 100% [####################]   7.00 KiB @  37.89 KiB/s (took 0s)                                                                                      Finished in 0.34s
 WARN probe_rs::probe::stlink: send_jtag_command 242 failed: SwdDpError
 WARN probe_rs::probe::stlink: send_jtag_command 242 failed: SwdDpError
 WARN probe_rs::session: Could not clear all hardware breakpoints: An ARM specific error occurred.

Caused by:
    0: The debug probe encountered an error.
    1: An error which is specific to the debug probe in use occurred.
    2: Command failed with status SwdDpError.
 WARN probe_rs::probe::stlink: send_jtag_command 242 failed: SwdDpError
 WARN probe_rs::session: Failed to deconfigure device during shutdown: Arm(Probe(ProbeSpecific(BoxedProbeError(CommandFailed(SwdDpError)))))
Error: An ARM specific error occurred.

Caused by:
    0: The debug probe encountered an error.
    1: An error which is specific to the debug probe in use occurred.
    2: Command failed with status SwdDpError.
```

Tested on a Nucleo-G474RE

```
$ rustc --version
rustc 1.83.0 (90b35a623 2024-11-26)
```