### PR TITLE
fix OPAMP opaintoen in PGA mode using internal output

### DIFF
--- a/src/opamp.rs
+++ b/src/opamp.rs
@@ -813,7 +813,7 @@ macro_rules! opamps {
                     gain: Gain,
                 ) -> Pga<$opamp, $non_inverting, InternalOutput>
                 {
-                    $opamp::configure_pga(InternalOutput, gain, PgaMode::Pga, true)
+                    $opamp::configure_pga(InternalOutput, gain, PgaMode::Pga, false)
                 }
 
                 #[allow(private_bounds)]
@@ -827,7 +827,7 @@ macro_rules! opamps {
                     _output: InternalOutput,
                     gain: Gain,
                 ) -> Pga<$opamp, $non_inverting, InternalOutput> {
-                    $opamp::configure_pga(InternalOutput, gain, PgaMode::PgaExternalFilter, true)
+                    $opamp::configure_pga(InternalOutput, gain, PgaMode::PgaExternalFilter, false)
                 }
 
                 #[allow(private_bounds)]
@@ -841,7 +841,7 @@ macro_rules! opamps {
                     _output: InternalOutput,
                     gain: Gain,
                 ) -> Pga<$opamp, $non_inverting, InternalOutput> {
-                    $opamp::configure_pga(InternalOutput, gain, PgaMode::PgaExternalBias, true)
+                    $opamp::configure_pga(InternalOutput, gain, PgaMode::PgaExternalBias, false)
                 }
 
                 #[allow(private_bounds)]
@@ -857,7 +857,7 @@ macro_rules! opamps {
                     _output: InternalOutput,
                     gain: Gain,
                 ) -> Pga<$opamp, $non_inverting, InternalOutput> {
-                    $opamp::configure_pga(InternalOutput, gain, PgaMode::PgaExternalBiasAndFilter, true)
+                    $opamp::configure_pga(InternalOutput, gain, PgaMode::PgaExternalBiasAndFilter, false)
                 }
             }
         }


### PR DESCRIPTION
`OPAMPX_CSR.OPAINTOEN` is incorrectly configured as 0 (OutputPin) even when the Opamp is configured using `InternalOutput` like this:

```
    opamp1.pga_external_bias(
        pins.pa1.into_analog(),
        pins.pa3.into_analog(),
        InternalOutput,
        Gain::Gain64,
    );
```

This PR fixes this by calling `configure_pga` with `output_enable=false` when `InternalOutput` is used.