### PR TITLE
Fix ADC data register address for DMA

### DIFF
--- a/src/adc.rs
+++ b/src/adc.rs
@@ -1863,7 +1863,7 @@ macro_rules! adc {
                 /// Returns the address of the ADC data register. Primarily useful for configuring DMA.
                 #[inline(always)]
                 pub fn data_register_address(&self) -> u32 {
-                    &self.adc_reg.dr() as *const _ as u32
+                    self.adc_reg.dr() as *const _ as u32
                 }
 
                 /// Calibrate the adc for <Input Type>

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -501,7 +501,7 @@ macro_rules! uart_shared {
             #[inline(always)]
             fn address(&self) -> u32 {
                 // unsafe: only the Tx part accesses the Tx register
-                &unsafe { &*<$USARTX>::ptr() }.tdr() as *const _ as u32
+                unsafe { &*<$USARTX>::ptr() }.tdr() as *const _ as u32
             }
 
             type MemSize = u8;
@@ -513,7 +513,7 @@ macro_rules! uart_shared {
             #[inline(always)]
             fn address(&self) -> u32 {
                 // unsafe: only the Rx part accesses the Rx register
-                &unsafe { &*<$USARTX>::ptr() }.rdr() as *const _ as u32
+                unsafe { &*<$USARTX>::ptr() }.rdr() as *const _ as u32
             }
 
             type MemSize = u8;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -213,7 +213,7 @@ macro_rules! spi {
                     // NOTE(read_volatile) read only 1 byte (the svd2rust API only allows
                     // reading a half-word)
                     return Ok(unsafe {
-                        ptr::read_volatile(&self.spi.dr() as *const _ as *const W)
+                        ptr::read_volatile(self.spi.dr() as *const _ as *const W)
                     });
                 } else {
                     nb::Error::WouldBlock
@@ -360,7 +360,7 @@ macro_rules! spi {
             #[inline(always)]
             fn address(&self) -> u32 {
                 // unsafe: only the Tx part accesses the Tx register
-                &unsafe { &*<$SPIX>::ptr() }.dr() as *const _ as u32
+                unsafe { &*<$SPIX>::ptr() }.dr() as *const _ as u32
             }
 
             type MemSize = u8;


### PR DESCRIPTION
We erroneously take a reference to a reference to the data registers which gives us an address to the stack

Fixes #194 