### PR TITLE
Implement EntitlementLock for Frozen

### DIFF
--- a/src/stasis.rs
+++ b/src/stasis.rs
@@ -77,6 +77,10 @@ impl<Resource: Freeze> EntitlementLock for Entitlement<Resource> {
     type Resource = Resource;
 }
 
+impl<Resource: Freeze, const N: usize> EntitlementLock for Frozen<Resource, N> {
+    type Resource = Resource;
+}
+
 /// Indicates a type-state is
 /// entitled to another type-state.
 ///


### PR DESCRIPTION
I just got cought by this error which was not super clear what the problem was when trying to use a `Frozen<R>` instead of an `Entitlement<R>` as an input:

```
error[E0277]: the trait bound `stm32g4xx_hal::stasis::Frozen<PB13<stm32g4xx_hal::gpio::Analog>, 1>: NonInverting<Opamp6>` is not satisfied
   --> src/hardware/v1_1/mod.rs:512:36
    |
512 |     let hv2_current_sense = opamp6.follower(
    |                                    ^^^^^^^^ the trait `NonInverting<Opamp6>` is not implemented for `stm32g4xx_hal::stasis::Frozen<PB13<stm32g4xx_hal::gpio::Analog>, 1>`
    |
    = help: the following other types implement trait `NonInverting<OPAMP>`:
              `PA1<stm32g4xx_hal::gpio::Analog>` implements `NonInverting<Opamp1>`
              `PA1<stm32g4xx_hal::gpio::Analog>` implements `NonInverting<Opamp3>`
              `PA3<stm32g4xx_hal::gpio::Analog>` implements `NonInverting<Opamp1>`
              `PA7<stm32g4xx_hal::gpio::Analog>` implements `NonInverting<Opamp1>`
              `PA7<stm32g4xx_hal::gpio::Analog>` implements `NonInverting<Opamp2>`
              `PB0<stm32g4xx_hal::gpio::Analog>` implements `NonInverting<Opamp2>`
              `PB0<stm32g4xx_hal::gpio::Analog>` implements `NonInverting<Opamp3>`
              `PB11<stm32g4xx_hal::gpio::Analog>` implements `NonInverting<Opamp4>`
            and 11 others
    = note: required for `stm32g4xx_hal::opamp::Disabled<Opamp6>` to implement `IntoFollower<Opamp6, stm32g4xx_hal::stasis::Frozen<PB13<stm32g4xx_hal::gpio::Analog>, 1>, InternalOutput>`

error[E0277]: the trait bound `Frozen<PB13<Analog>, 1>: Freeze` is not satisfied
   --> src/hardware/v1_1/mod.rs:512:36
    |
512 |     let hv2_current_sense = opamp6.follower(
    |                                    ^^^^^^^^ the trait `stm32g4xx_hal::stasis::Freeze` is not implemented for `stm32g4xx_hal::stasis::Frozen<PB13<stm32g4xx_hal::gpio::Analog>, 1>`
    |
    = help: the following other types implement trait `stm32g4xx_hal::stasis::Freeze`:
              DacCh<DAC, CH, MODE_BITS, ED>
              Follower<Opamp1, Input, Output>
              Follower<Opamp2, Input, Output>
              Follower<Opamp3, Input, Output>
              Follower<Opamp4, Input, Output>
              Follower<Opamp5, Input, Output>
              Follower<Opamp6, Input, Output>
              OpenLoop<Opamp1, NonInverting, Inverting, Output>
            and 136 others
    = note: required for `stm32g4xx_hal::stasis::Frozen<PB13<stm32g4xx_hal::gpio::Analog>, 1>` to implement `EntitlementLock`
    = note: required for `stm32g4xx_hal::opamp::Disabled<Opamp6>` to implement `IntoFollower<Opamp6, stm32g4xx_hal::stasis::Frozen<PB13<stm32g4xx_hal::gpio::Analog>, 1>, InternalOutput>`
    = note: the full name for the type has been written to 'control/target/thumbv7em-none-eabihf/release/deps/control-d0992a961e573d55.long-type-17721821904167839764.txt'
    = note: consider using `--verbose` to print the full type name to the console
```

@AdinAck do you see any reason to not do my proposed change?