### PR TITLE
DAC Improvements - Dual DAC support and DMA

### DIFF
--- a/src/dac/dual.rs
+++ b/src/dac/dual.rs
@@ -1,0 +1,206 @@
+#![deny(missing_docs)]
+
+//! Dual DAC
+//!
+//! This module provides access to the dual DAC channels of the STM32G4 series microcontrollers.
+//! It allows for simultaneous access to both DAC channels and supports DMA transfers.
+//!
+
+use core::marker::PhantomData;
+
+use embedded_hal::delay::DelayNs;
+
+use crate::dac::{
+    format::SampleFormat, trigger::DacTriggerSource, DacCh, DacChannel, Disabled, Enabled,
+    Instance, M_EXT_PIN,
+};
+use crate::dac::{hfsel, DacExt as _, Pins};
+
+use crate::dac::format::{self, ToDac as _};
+use crate::dma::mux::DmaMuxResources;
+use crate::dma::traits::TargetAddress;
+use crate::dma::MemoryToPeripheral;
+use crate::rcc::Rcc;
+
+/// Extension trait for [`Instance`] to create a [`DualDac`] from the given pins and RCC.
+pub trait DualDacExt: Instance + Sized {
+    /// Create a dual DAC instance from the given pins and RCC.
+    ///
+    /// DAC calibration is performed before enabling the DAC, so
+    /// a DelayNs implementation is required.
+    ///
+    /// This uses the dual hold registers (DHR12xD, DHR8RD) and
+    /// can write to both DAC channels simultaneously with DMA support.
+    fn into_dual<F: SampleFormat, PINS>(
+        self,
+        pins: PINS,
+        rcc: &mut Rcc,
+        delay: &mut impl DelayNs,
+    ) -> DualDac<Self, F, Disabled>
+    where
+        PINS: Pins<
+            Self,
+            Output = (
+                DacCh<Self, 0, M_EXT_PIN, Disabled>,
+                DacCh<Self, 1, M_EXT_PIN, Disabled>,
+            ),
+        >;
+}
+
+/// Dual DAC handle
+pub struct DualDac<DAC: Instance, F: SampleFormat, State> {
+    _ch1: DacCh<DAC, 0, M_EXT_PIN, State>,
+    _ch2: DacCh<DAC, 1, M_EXT_PIN, State>,
+    _phantom: PhantomData<F>,
+}
+
+impl<DAC: Instance, F: SampleFormat> DualDac<DAC, F, Disabled> {
+    /// Enable DMA double mode for the specified channel.
+    /// This creates a single DMA request for every
+    /// two external hardware triggers (excluding software triggers).
+    #[inline(always)]
+    pub fn enable_dma_double(&mut self, channel: u8, enable: bool) {
+        let dac = unsafe { &(*DAC::ptr()) };
+        if enable {
+            dac.mcr().modify(|_, w| w.dmadouble(channel).set_bit());
+        } else {
+            dac.mcr().modify(|_, w| w.dmadouble(channel).clear_bit());
+        }
+    }
+
+    /// Enable DMA for the specified channel
+    #[inline(always)]
+    pub fn enable_dma(&mut self, channel: DacChannel, enable: bool) {
+        let dac = unsafe { &(*DAC::ptr()) };
+        if enable {
+            dac.cr().modify(|_, w| w.dmaen(channel as u8).set_bit());
+        } else {
+            dac.cr().modify(|_, w| w.dmaen(channel as u8).clear_bit());
+        }
+    }
+
+    /// Enable trigger for the specified channel and the [`DacTriggerSource`]
+    /// provided as a generic type parameter.
+    ///
+    /// This will cause the DAC to copy the hold register to the output register
+    /// when the trigger is raised by a timer signal or external interrupt,
+    /// and issue a new DMA request if DMA is enabled.
+    #[inline(always)]
+    pub fn enable_trigger<Source>(&mut self, channel: DacChannel)
+    where
+        Source: DacTriggerSource<DAC>,
+    {
+        // Set the TSELx bits to the trigger signal identifier from the DacTriggerSource impl
+        let dac = unsafe { &(*DAC::ptr()) };
+        match channel {
+            DacChannel::Ch1 => {
+                unsafe { dac.cr().modify(|_, w| w.tsel1().bits(Source::SIGNAL)) };
+            }
+            DacChannel::Ch2 => {
+                unsafe { dac.cr().modify(|_, w| w.tsel2().bits(Source::SIGNAL)) };
+            }
+        }
+
+        // Enable the TENx flag in DAC CR
+        dac.cr().modify(|_, w| w.ten(channel as u8).set_bit());
+    }
+
+    /// Enable both DAC channels
+    #[inline(always)]
+    pub fn enable(self) -> DualDac<DAC, F, Enabled> {
+        let dac = unsafe { &(*DAC::ptr()) };
+
+        dac.cr().modify(|_, w| w.en(0).set_bit().en(1).set_bit());
+        DualDac {
+            _ch1: DacCh::new(),
+            _ch2: DacCh::new(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<DAC: Instance, F: SampleFormat> DualDac<DAC, F, Enabled> {
+    /// Write to both DAC channels simultaneously.
+    #[inline(always)]
+    pub fn set_channels(&mut self, ch1: F::Scalar, ch2: F::Scalar) {
+        let dac = unsafe { &(*DAC::ptr()) };
+
+        let bits = (ch2.to_dac() as u32) << F::CH2_SHIFT | (ch1.to_dac() as u32) & F::CH1_MASK;
+
+        match F::DEPTH {
+            format::SampleDepth::Bits12 => match F::ALIGNMENT {
+                format::Alignment::Left => {
+                    dac.dhr12ld().write(|w| unsafe { w.bits(bits as u32) });
+                }
+                format::Alignment::Right => {
+                    dac.dhr12rd().write(|w| unsafe { w.bits(bits as u32) });
+                }
+            },
+            format::SampleDepth::Bits8 => {
+                // NOTE: 8-bit is always right aligned
+                dac.dhr8rd().write(|w| unsafe { w.bits(bits as u32) });
+            }
+        }
+    }
+}
+
+impl<DAC: Instance> DualDacExt for DAC {
+    fn into_dual<F: SampleFormat, PINS>(
+        self,
+        pins: PINS,
+        rcc: &mut Rcc,
+        delay: &mut impl DelayNs,
+    ) -> DualDac<DAC, F, Disabled>
+    where
+        PINS: Pins<
+            Self,
+            Output = (
+                DacCh<Self, 0, M_EXT_PIN, Disabled>,
+                DacCh<Self, 1, M_EXT_PIN, Disabled>,
+            ),
+        >,
+    {
+        let (ch1, ch2) = self.constrain(pins, rcc);
+
+        let ch1 = ch1.calibrate_buffer(delay);
+        let ch2 = ch2.calibrate_buffer(delay);
+
+        // Configure HFSEL
+        let dac = unsafe { &(*DAC::ptr()) };
+        let hfsel = hfsel(rcc);
+        dac.mcr().modify(|_, w| w.hfsel().variant(hfsel));
+
+        // Apply the format configuration to both channels
+        for channel in 0..2 {
+            match F::SIGNED {
+                true => {
+                    dac.mcr().modify(|_, w| w.sinformat(channel).set_bit());
+                }
+                false => {
+                    dac.mcr().modify(|_, w| w.sinformat(channel).clear_bit());
+                }
+            };
+        }
+
+        DualDac {
+            _ch1: ch1,
+            _ch2: ch2,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+unsafe impl<DAC: Instance, F: SampleFormat, State> TargetAddress<MemoryToPeripheral>
+    for DualDac<DAC, F, State>
+{
+    type MemSize = u32;
+    const REQUEST_LINE: Option<u8> = Some(DmaMuxResources::DAC1_CH1 as u8);
+
+    fn address(&self) -> u32 {
+        let dac = unsafe { &(*DAC::ptr()) };
+        match F::SIGNED {
+            true => dac.dhr12ld() as *const _ as u32,
+            false => dac.dhr12rd() as *const _ as u32,
+        }
+    }
+}

--- a/src/dac/format.rs
+++ b/src/dac/format.rs
@@ -1,0 +1,119 @@
+//! STM32G4 DAC Data Sample Formats
+
+use fixed::types::{I1F15, I1F7};
+
+/// DAC Data Alignment
+pub enum Alignment {
+    Left,
+    Right,
+}
+
+pub enum SampleDepth {
+    Bits12,
+    Bits8,
+}
+
+pub trait SampleFormat {
+    /// Bit depth of the sample format (8 or 12 bits)
+    const DEPTH: SampleDepth;
+    /// Alignment of the samples in the DAC hold register.
+    /// Left alignment is used for signed 2's complement data
+    const ALIGNMENT: Alignment;
+    /// Signedness of the sample format
+    const SIGNED: bool;
+    /// Shift amount for Channel 2 samples into the 32 bit hold register
+    const CH2_SHIFT: u8;
+    /// Mask for Channel 1 samples in the 32 bit hold register
+    const CH1_MASK: u32;
+
+    /// Scalar type for this sample format
+    /// Q1.7, Q1.11, Q1.15 use fixed types, unsigned are u8 or u16
+    type Scalar: ToDac;
+}
+
+/// Conversion trait for DAC data. Used to support conversion from
+/// fixed point types to their bit representation as u16.
+pub trait ToDac {
+    fn to_dac(&self) -> u16;
+}
+
+impl ToDac for I1F7 {
+    fn to_dac(&self) -> u16 {
+        self.to_bits() as u16
+    }
+}
+
+impl ToDac for I1F15 {
+    fn to_dac(&self) -> u16 {
+        self.to_bits() as u16
+    }
+}
+
+impl ToDac for u16 {
+    #[inline(always)]
+    fn to_dac(&self) -> u16 {
+        *self
+    }
+}
+
+impl ToDac for u8 {
+    #[inline(always)]
+    fn to_dac(&self) -> u16 {
+        *self as u16
+    }
+}
+
+/// Unsigned 8-bit samples
+pub struct SampleU8;
+impl SampleFormat for SampleU8 {
+    const DEPTH: SampleDepth = SampleDepth::Bits8;
+    const ALIGNMENT: Alignment = Alignment::Right;
+    const SIGNED: bool = false;
+    const CH2_SHIFT: u8 = 8;
+    const CH1_MASK: u32 = 0xFF;
+    type Scalar = u8;
+}
+
+/// Unsigned 12-bit samples
+pub struct SampleU12;
+impl SampleFormat for SampleU12 {
+    const DEPTH: SampleDepth = SampleDepth::Bits12;
+    const ALIGNMENT: Alignment = Alignment::Right;
+    const SIGNED: bool = false;
+    const CH2_SHIFT: u8 = 16;
+    const CH1_MASK: u32 = 0xFFFF;
+    type Scalar = u16;
+}
+
+/// Fixed point signed Q1.7 samples
+pub struct SampleQ7;
+impl SampleFormat for SampleQ7 {
+    const DEPTH: SampleDepth = SampleDepth::Bits8;
+    const ALIGNMENT: Alignment = Alignment::Right;
+    const SIGNED: bool = true;
+    const CH2_SHIFT: u8 = 8;
+    const CH1_MASK: u32 = 0xFF;
+    type Scalar = I1F7;
+}
+
+/// Fixed point signed Q1.11 samples
+pub struct SampleQ11;
+impl SampleFormat for SampleQ11 {
+    const DEPTH: SampleDepth = SampleDepth::Bits12;
+    const ALIGNMENT: Alignment = Alignment::Left;
+    const SIGNED: bool = true;
+    const CH2_SHIFT: u8 = 16;
+    const CH1_MASK: u32 = 0xFFFF;
+    type Scalar = I1F15;
+}
+
+/// Fixed point signed Q1.15 samples
+pub struct SampleQ15;
+impl SampleFormat for SampleQ15 {
+    const DEPTH: SampleDepth = SampleDepth::Bits12;
+    const ALIGNMENT: Alignment = Alignment::Left;
+    const SIGNED: bool = true;
+    const CH2_SHIFT: u8 = 16;
+    const CH1_MASK: u32 = 0xFFFF;
+    type Scalar = I1F15;
+}

--- a/src/dac/trigger.rs
+++ b/src/dac/trigger.rs
@@ -1,0 +1,212 @@
+use crate::dac::Instance;
+use crate::stm32::{DAC1, DAC2, DAC3, DAC4};
+
+pub trait DacTriggerSource<DAC: Instance> {
+    const SIGNAL: u8;
+
+    #[inline(always)]
+    fn signal(&self) -> u8 {
+        Self::SIGNAL
+    }
+}
+
+pub trait DacIncrementSource<DAC: Instance> {
+    const SIGNAL: u8;
+
+    #[inline(always)]
+    fn signal(&self) -> u8 {
+        Self::SIGNAL
+    }
+}
+
+/// Implements the struct representing a DAC trigger source.
+/// Sources which are valid for a DAC instance will have a [`DacTriggerSource`]
+/// trait implemented on them with the const SIGNAL set to the signal
+/// interconnection from RM0440 Table 187
+macro_rules! impl_dac_trigger {
+    ($($source:ident)+) => {$(
+        pub struct $source;
+    )+};
+}
+
+impl_dac_trigger!(Software);
+impl_dac_trigger!(Timer1);
+impl_dac_trigger!(Timer2);
+impl_dac_trigger!(Timer3);
+impl_dac_trigger!(Timer4);
+impl_dac_trigger!(Timer5);
+impl_dac_trigger!(Timer6);
+impl_dac_trigger!(Timer7);
+impl_dac_trigger!(Timer8);
+impl_dac_trigger!(Timer15);
+
+impl_dac_trigger!(HrtimDacReset1);
+impl_dac_trigger!(HrtimDacReset2);
+impl_dac_trigger!(HrtimDacReset3);
+impl_dac_trigger!(HrtimDacReset4);
+impl_dac_trigger!(HrtimDacReset5);
+impl_dac_trigger!(HrtimDacReset6);
+impl_dac_trigger!(HrtimDacTrigger1);
+impl_dac_trigger!(HrtimDacTrigger2);
+impl_dac_trigger!(HrtimDacTrigger3);
+impl_dac_trigger!(HrtimDacStep1);
+impl_dac_trigger!(HrtimDacStep2);
+impl_dac_trigger!(HrtimDacStep3);
+impl_dac_trigger!(HrtimDacStep4);
+impl_dac_trigger!(HrtimDacStep5);
+impl_dac_trigger!(HrtimDacStep6);
+
+impl_dac_trigger!(Exti9);
+impl_dac_trigger!(Exti10);
+
+/// Macro to implement the DacTriggerSource trait for each supported trigger source
+/// specific to each DAC peripheral instance.
+macro_rules! impl_dac_channel_trigger {
+    ($($DAC:ty, $source:ident, $signal:expr)+) => {$(
+        impl DacTriggerSource<$DAC> for $source {
+            const SIGNAL: u8 = $signal;
+        }
+    )+};
+}
+
+/// Macro to implement the DacIncrementSource trait for each supported
+/// increment trigger source specific to each DAC peripheral instance.
+macro_rules! impl_dac_increment_trigger {
+    ($($DAC:ty, $source:ident, $signal:expr)+) => {$(
+        impl DacIncrementSource<$DAC> for $source {
+            const SIGNAL: u8 = $signal;
+        }
+    )+};
+}
+
+impl_dac_channel_trigger!(DAC1, Software, 0);
+impl_dac_channel_trigger!(DAC1, Timer8, 1);
+impl_dac_channel_trigger!(DAC1, Timer7, 2);
+impl_dac_channel_trigger!(DAC1, Timer15, 3);
+impl_dac_channel_trigger!(DAC1, Timer2, 4);
+impl_dac_channel_trigger!(DAC1, Timer4, 5);
+impl_dac_channel_trigger!(DAC1, Exti9, 6);
+impl_dac_channel_trigger!(DAC1, Timer6, 7);
+impl_dac_channel_trigger!(DAC1, Timer3, 8);
+impl_dac_channel_trigger!(DAC1, HrtimDacReset1, 9);
+impl_dac_channel_trigger!(DAC1, HrtimDacReset2, 10);
+impl_dac_channel_trigger!(DAC1, HrtimDacReset3, 11);
+impl_dac_channel_trigger!(DAC1, HrtimDacReset4, 12);
+impl_dac_channel_trigger!(DAC1, HrtimDacReset5, 13);
+impl_dac_channel_trigger!(DAC1, HrtimDacReset6, 14);
+impl_dac_channel_trigger!(DAC1, HrtimDacTrigger1, 15);
+
+impl_dac_increment_trigger!(DAC1, Software, 0);
+impl_dac_increment_trigger!(DAC1, Timer8, 1);
+impl_dac_increment_trigger!(DAC1, Timer7, 2);
+impl_dac_increment_trigger!(DAC1, Timer15, 3);
+impl_dac_increment_trigger!(DAC1, Timer2, 4);
+impl_dac_increment_trigger!(DAC1, Timer4, 5);
+impl_dac_increment_trigger!(DAC1, Exti10, 6);
+impl_dac_increment_trigger!(DAC1, Timer6, 7);
+impl_dac_increment_trigger!(DAC1, Timer3, 8);
+impl_dac_increment_trigger!(DAC1, HrtimDacStep1, 9);
+impl_dac_increment_trigger!(DAC1, HrtimDacStep2, 10);
+impl_dac_increment_trigger!(DAC1, HrtimDacStep3, 11);
+impl_dac_increment_trigger!(DAC1, HrtimDacStep4, 12);
+impl_dac_increment_trigger!(DAC1, HrtimDacStep5, 13);
+impl_dac_increment_trigger!(DAC1, HrtimDacStep6, 14);
+
+impl_dac_channel_trigger!(DAC2, Software, 0);
+impl_dac_channel_trigger!(DAC2, Timer8, 1);
+impl_dac_channel_trigger!(DAC2, Timer7, 2);
+impl_dac_channel_trigger!(DAC2, Timer15, 3);
+impl_dac_channel_trigger!(DAC2, Timer2, 4);
+impl_dac_channel_trigger!(DAC2, Timer4, 5);
+impl_dac_channel_trigger!(DAC2, Exti9, 6);
+impl_dac_channel_trigger!(DAC2, Timer6, 7);
+impl_dac_channel_trigger!(DAC2, Timer3, 8);
+impl_dac_channel_trigger!(DAC2, HrtimDacReset1, 9);
+impl_dac_channel_trigger!(DAC2, HrtimDacReset2, 10);
+impl_dac_channel_trigger!(DAC2, HrtimDacReset3, 11);
+impl_dac_channel_trigger!(DAC2, HrtimDacReset4, 12);
+impl_dac_channel_trigger!(DAC2, HrtimDacReset5, 13);
+impl_dac_channel_trigger!(DAC2, HrtimDacReset6, 14);
+impl_dac_channel_trigger!(DAC2, HrtimDacTrigger2, 15);
+
+impl_dac_increment_trigger!(DAC2, Software, 0);
+impl_dac_increment_trigger!(DAC2, Timer8, 1);
+impl_dac_increment_trigger!(DAC2, Timer7, 2);
+impl_dac_increment_trigger!(DAC2, Timer15, 3);
+impl_dac_increment_trigger!(DAC2, Timer2, 4);
+impl_dac_increment_trigger!(DAC2, Timer4, 5);
+impl_dac_increment_trigger!(DAC2, Exti10, 6);
+impl_dac_increment_trigger!(DAC2, Timer6, 7);
+impl_dac_increment_trigger!(DAC2, Timer3, 8);
+impl_dac_increment_trigger!(DAC2, HrtimDacStep1, 9);
+impl_dac_increment_trigger!(DAC2, HrtimDacStep2, 10);
+impl_dac_increment_trigger!(DAC2, HrtimDacStep3, 11);
+impl_dac_increment_trigger!(DAC2, HrtimDacStep4, 12);
+impl_dac_increment_trigger!(DAC2, HrtimDacStep5, 13);
+impl_dac_increment_trigger!(DAC2, HrtimDacStep6, 14);
+
+impl_dac_channel_trigger!(DAC3, Software, 1);
+impl_dac_channel_trigger!(DAC3, Timer1, 1);
+impl_dac_channel_trigger!(DAC3, Timer7, 2);
+impl_dac_channel_trigger!(DAC3, Timer15, 3);
+impl_dac_channel_trigger!(DAC3, Timer2, 4);
+impl_dac_channel_trigger!(DAC3, Timer4, 5);
+impl_dac_channel_trigger!(DAC3, Exti9, 6);
+impl_dac_channel_trigger!(DAC3, Timer6, 7);
+impl_dac_channel_trigger!(DAC3, Timer3, 8);
+impl_dac_channel_trigger!(DAC3, HrtimDacReset1, 9);
+impl_dac_channel_trigger!(DAC3, HrtimDacReset2, 10);
+impl_dac_channel_trigger!(DAC3, HrtimDacReset3, 11);
+impl_dac_channel_trigger!(DAC3, HrtimDacReset4, 12);
+impl_dac_channel_trigger!(DAC3, HrtimDacReset5, 13);
+impl_dac_channel_trigger!(DAC3, HrtimDacReset6, 14);
+impl_dac_channel_trigger!(DAC3, HrtimDacTrigger3, 15);
+
+impl_dac_increment_trigger!(DAC3, Software, 0);
+impl_dac_increment_trigger!(DAC3, Timer1, 1);
+impl_dac_increment_trigger!(DAC3, Timer7, 2);
+impl_dac_increment_trigger!(DAC3, Timer15, 3);
+impl_dac_increment_trigger!(DAC3, Timer2, 4);
+impl_dac_increment_trigger!(DAC3, Timer4, 5);
+impl_dac_increment_trigger!(DAC3, Exti10, 6);
+impl_dac_increment_trigger!(DAC3, Timer6, 7);
+impl_dac_increment_trigger!(DAC3, Timer3, 8);
+impl_dac_increment_trigger!(DAC3, HrtimDacStep1, 9);
+impl_dac_increment_trigger!(DAC3, HrtimDacStep2, 10);
+impl_dac_increment_trigger!(DAC3, HrtimDacStep3, 11);
+impl_dac_increment_trigger!(DAC3, HrtimDacStep4, 12);
+impl_dac_increment_trigger!(DAC3, HrtimDacStep5, 13);
+impl_dac_increment_trigger!(DAC3, HrtimDacStep6, 14);
+
+impl_dac_channel_trigger!(DAC4, Software, 1);
+impl_dac_channel_trigger!(DAC4, Timer8, 1);
+impl_dac_channel_trigger!(DAC4, Timer7, 2);
+impl_dac_channel_trigger!(DAC4, Timer15, 3);
+impl_dac_channel_trigger!(DAC4, Timer2, 4);
+impl_dac_channel_trigger!(DAC4, Timer4, 5);
+impl_dac_channel_trigger!(DAC4, Exti9, 6);
+impl_dac_channel_trigger!(DAC4, Timer6, 7);
+impl_dac_channel_trigger!(DAC4, Timer3, 8);
+impl_dac_channel_trigger!(DAC4, HrtimDacReset1, 9);
+impl_dac_channel_trigger!(DAC4, HrtimDacReset2, 10);
+impl_dac_channel_trigger!(DAC4, HrtimDacReset3, 11);
+impl_dac_channel_trigger!(DAC4, HrtimDacReset4, 12);
+impl_dac_channel_trigger!(DAC4, HrtimDacReset5, 13);
+impl_dac_channel_trigger!(DAC4, HrtimDacReset6, 14);
+impl_dac_channel_trigger!(DAC4, HrtimDacTrigger1, 15);
+
+impl_dac_increment_trigger!(DAC4, Software, 0);
+impl_dac_increment_trigger!(DAC4, Timer8, 1);
+impl_dac_increment_trigger!(DAC4, Timer7, 2);
+impl_dac_increment_trigger!(DAC4, Timer15, 3);
+impl_dac_increment_trigger!(DAC4, Timer2, 4);
+impl_dac_increment_trigger!(DAC4, Timer4, 5);
+impl_dac_increment_trigger!(DAC4, Exti10, 6);
+impl_dac_increment_trigger!(DAC4, Timer6, 7);
+impl_dac_increment_trigger!(DAC4, Timer3, 8);
+impl_dac_increment_trigger!(DAC4, HrtimDacStep1, 9);
+impl_dac_increment_trigger!(DAC4, HrtimDacStep2, 10);
+impl_dac_increment_trigger!(DAC4, HrtimDacStep3, 11);
+impl_dac_increment_trigger!(DAC4, HrtimDacStep4, 12);
+impl_dac_increment_trigger!(DAC4, HrtimDacStep5, 13);
+impl_dac_increment_trigger!(DAC4, HrtimDacStep6, 14);

--- a/src/dma/traits.rs
+++ b/src/dma/traits.rs
@@ -176,7 +176,7 @@ pub trait Direction {
 /// and for the DMA.
 pub unsafe trait TargetAddress<D: Direction> {
     /// Memory size of the target address
-    type MemSize;
+    type MemSize: 'static;
 
     /// The address to be used by the DMA channel
     fn address(&self) -> u32;


### PR DESCRIPTION
* Add `DualDac` with simultaneous channel writes, with DMA support
* Added `SampleFormat` trait and impls supporting Q1.7, Q1.11, Q1.15 signed and unsigned 8/11b types, left/right alignment
* Added `DacTriggerSource` and `DacIncrementSource` traits for selecting external trigger sources with DAC instance constraints
* Added DMA support to existing single channel DACs

Here's an example of using a circular phase angle buffer which is DMA'd into CORDIC in SinCos mode, with DualDac configured to DMA samples directly from CORDIC RDATA register in Q1.15 format, and triggered by Tim6 at 1MHz. This produces a quadrature output on both DAC1 channels, with zero CPU.

![DualDac Quadrature CORDIC DMA](https://github.com/user-attachments/assets/04cbdd13-017b-4588-8c41-e2c6174dbecd)
