### PR TITLE
Demacrofy SPI

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -440,7 +440,7 @@ impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u8> for Spi<SPI, 
             core::slice::from_raw_parts_mut(ptr as *mut [u8; 2], half_len)
         };
 
-        for b in words_alias.iter_mut().take(prefill as usize) {
+        for b in words_alias.iter_mut().take(prefill) {
             nb::block!(self.nb_write(u16::from_le_bytes(*b)))?;
         }
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -198,13 +198,13 @@ impl<SPI: Instance, PINS> Spi<SPI, PINS> {
     pub fn set_tx_only(&mut self) {
         self.spi
             .cr1()
-            .modify(|_, w| w.bidimode().set_bit().bidioe().set_bit());
+            .modify(|_, w| w.bidimode().bidirectional().bidioe().output_enabled());
     }
     #[inline]
     pub fn set_bidi(&mut self) {
         self.spi
             .cr1()
-            .modify(|_, w| w.bidimode().clear_bit().bidioe().clear_bit());
+            .modify(|_, w| w.bidimode().unidirectional().bidioe().output_disabled());
     }
     fn tx_fifo_cap(&self) -> u8 {
         match self.spi.sr().read().ftlvl().bits() {
@@ -271,7 +271,7 @@ fn setup_spi_regs(regs: &spi1::RegisterBlock, spi_freq: u32, bus_freq: u32, mode
             .rxonly()
             .clear_bit()
             .bidimode()
-            .clear_bit()
+            .unidirectional()
             .ssi()
             .set_bit()
             .spe()

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -2,7 +2,7 @@ use crate::dma::mux::DmaMuxResources;
 use crate::dma::traits::TargetAddress;
 use crate::dma::MemoryToPeripheral;
 use crate::gpio;
-use crate::rcc::{Enable, GetBusFreq, Rcc, RccBus, Reset};
+use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
 #[cfg(any(
     feature = "stm32g473",
     feature = "stm32g474",
@@ -10,7 +10,7 @@ use crate::rcc::{Enable, GetBusFreq, Rcc, RccBus, Reset};
     feature = "stm32g484"
 ))]
 use crate::stm32::SPI4;
-use crate::stm32::{SPI1, SPI2, SPI3};
+use crate::stm32::{spi1, SPI1, SPI2, SPI3};
 use crate::time::Hertz;
 use core::ptr;
 
@@ -85,6 +85,21 @@ impl FrameSize for u16 {
     const DFF: bool = true;
 }
 
+pub trait Instance:
+    crate::Sealed
+    // everything derefs to spi4, except spi1
+    // + Deref<Target = crate::stm32::spi1::RegisterBlock>
+    + Enable
+    + Reset
+    + GetBusFreq
+{
+    const PTR: *const spi1::RegisterBlock;
+    #[inline]
+    fn registers(&self) -> &spi1::RegisterBlock {
+        unsafe { &*Self::PTR }
+    }
+}
+
 macro_rules! spi {
     ($SPIX:ident, $spiX:ident,
         sck: [ $($( #[ $pmetasck:meta ] )* $SCK:ident<$ASCK:ident>,)+ ],
@@ -93,9 +108,7 @@ macro_rules! spi {
         $mux:expr,
     ) => {
         impl PinSck<$SPIX> for NoSck {}
-
         impl PinMiso<$SPIX> for NoMiso {}
-
         impl PinMosi<$SPIX> for NoMosi {}
 
         $(
@@ -111,256 +124,501 @@ macro_rules! spi {
             impl PinMosi<$SPIX> for gpio::$MOSI<gpio::$AMOSI> {}
         )*
 
-        impl<PINS: Pins<$SPIX>> Spi<$SPIX, PINS> {
-            pub fn $spiX<T>(
-                spi: $SPIX,
-                pins: PINS,
-                mode: Mode,
-                speed: T,
-                rcc: &mut Rcc
-            ) -> Self
-            where
-            T: Into<Hertz>
-            {
-                 // Enable and reset SPI
-                    $SPIX::enable(rcc);
-                    $SPIX::reset(rcc);
-
-                // disable SS output
-                spi.cr2().write(|w| w.ssoe().disabled());
-
-                let spi_freq = speed.into().raw();
-                let bus_freq = <$SPIX as RccBus>::Bus::get_frequency(&rcc.clocks).raw();
-                let br = match bus_freq / spi_freq {
-                    0 => unreachable!(),
-                    1..=2 => 0b000,
-                    3..=5 => 0b001,
-                    6..=11 => 0b010,
-                    12..=23 => 0b011,
-                    24..=47 => 0b100,
-                    48..=95 => 0b101,
-                    96..=191 => 0b110,
-                    _ => 0b111,
-                };
-
-                spi.cr2().write(|w| {
-                    w.frxth().quarter().ds().eight_bit().ssoe().disabled()
-                });
-
-                spi.cr1().write(|w| unsafe {
-                    w.cpha()
-                        .bit(mode.phase == Phase::CaptureOnSecondTransition)
-                        .cpol()
-                        .bit(mode.polarity == Polarity::IdleHigh)
-                        .mstr()
-                        .master()
-                        .br()
-                        .bits(br)
-                        .lsbfirst()
-                        .msbfirst()
-                        .ssm()
-                        .enabled()
-                        .ssi()
-                        .slave_not_selected()
-                        .rxonly()
-                        .full_duplex()
-                        .crcl()
-                        .eight_bit()
-                        .bidimode()
-                        .unidirectional()
-                        .spe()
-                        .enabled()
-                });
-
-                Spi { spi, pins }
-            }
-
-            pub fn release(self) -> ($SPIX, PINS) {
-                (self.spi, self.pins)
-            }
-
-            pub fn enable_tx_dma(self) -> Spi<$SPIX, PINS> {
-                self.spi.cr2().modify(|_, w| w.txdmaen().enabled());
-                Spi {
-                    spi: self.spi,
-                    pins: self.pins,
-                }
-            }
+        impl Instance for $SPIX {
+            const PTR: *const crate::stm32::spi1::RegisterBlock = $SPIX::PTR as *const crate::stm32::spi1::RegisterBlock;
         }
 
-        impl<PINS> Spi<$SPIX, PINS> {
-            fn nb_read<W: FrameSize>(&mut self) -> nb::Result<W, Error> {
-                let sr = self.spi.sr().read();
-                Err(if sr.ovr().bit_is_set() {
-                    nb::Error::Other(Error::Overrun)
-                } else if sr.modf().bit_is_set() {
-                    nb::Error::Other(Error::ModeFault)
-                } else if sr.crcerr().bit_is_set() {
-                    nb::Error::Other(Error::Crc)
-                } else if sr.rxne().bit_is_set() {
-                    // NOTE(read_volatile) read only 1 byte (the svd2rust API only allows
-                    // reading a half-word)
-                    return Ok(unsafe {
-                        ptr::read_volatile(self.spi.dr() as *const _ as *const W)
-                    });
-                } else {
-                    nb::Error::WouldBlock
-                })
-            }
-            fn nb_write<W: FrameSize>(&mut self, word: W) -> nb::Result<(), Error> {
-                let sr = self.spi.sr().read();
-                Err(if sr.ovr().bit_is_set() {
-                    nb::Error::Other(Error::Overrun)
-                } else if sr.modf().bit_is_set() {
-                    nb::Error::Other(Error::ModeFault)
-                } else if sr.crcerr().bit_is_set() {
-                    nb::Error::Other(Error::Crc)
-                } else if sr.txe().bit_is_set() {
-                    let dr = self.spi.dr().as_ptr() as *mut W;
-                    // NOTE(write_volatile) see note above
-                    unsafe { ptr::write_volatile(dr, word) };
-                    return Ok(());
-                } else {
-                    nb::Error::WouldBlock
-                })
-            }
-
-            fn set_tx_only(&mut self) {
-                self.spi
-                    .cr1()
-                    .modify(|_, w| w.bidimode().bidirectional().bidioe().output_enabled());
-            }
-
-            fn set_bidi(&mut self) {
-                self.spi
-                    .cr1()
-                    .modify(|_, w| w.bidimode().unidirectional().bidioe().output_disabled());
-            }
-        }
-
-        impl SpiExt<$SPIX> for $SPIX {
-            fn spi<PINS, T>(self, pins: PINS, mode: Mode, freq: T, rcc: &mut Rcc) -> Spi<$SPIX, PINS>
-            where
-                PINS: Pins<$SPIX>,
-                T: Into<Hertz>
-                {
-                    Spi::$spiX(self, pins, mode, freq, rcc)
-                }
-        }
-
-        impl<PINS> embedded_hal::spi::ErrorType for Spi<$SPIX, PINS> {
-            type Error = Error;
-        }
-
-        impl<PINS> embedded_hal::spi::SpiBus<u8> for Spi<$SPIX, PINS> {
-            fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
-                if words.len() == 0 { return Ok(()) }
-                // clear tx-only status in the case the previous operation was a write
-                self.set_bidi();
-                // prefill write fifo so that the clock doen't stop while fetch the read byte
-                // one frame should be enough?
-                nb::block!(self.nb_write(0u8))?;
-                let len = words.len();
-                for w in words[..len-1].iter_mut() {
-                    // TODO: 16 bit frames, bidirectional pins
-                    nb::block!(self.nb_write(0u8))?;
-                    *w = nb::block!(self.nb_read())?;
-                }
-                // safety: length > 0 checked at start of function
-                *words.last_mut().unwrap() = nb::block!(self.nb_read())?;
-                Ok(())
-            }
-
-            fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-                self.set_tx_only();
-                Ok(for w in words {
-                    nb::block!(self.nb_write(*w))?
-                })
-            }
-
-            fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
-                if read.len() == 0 {
-                    return self.write(write)
-                } else if write.len() == 0 {
-                    return self.read(read)
-                }
-
-                self.set_bidi();
-                // same prefill as in read, this time with actual data
-                nb::block!(self.nb_write(write[0]))?;
-                let common_len = core::cmp::min(read.len(), write.len());
-                // take 1 less because write skips the first element
-                let zipped = read.iter_mut().zip(write.into_iter().skip(1)).take(common_len - 1);
-                for (r, w) in zipped {
-                    nb::block!(self.nb_write(*w))?;
-                    *r = nb::block!(self.nb_read())?;
-                }
-                read[common_len-1] = nb::block!(self.nb_read())?;
-
-                if read.len() > common_len {
-                    self.read(&mut read[common_len..])
-                } else {
-                    self.write(&write[common_len..])
-                }
-            }
-            fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
-                if words.len() == 0 { return Ok(()) }
-                self.set_bidi();
-                nb::block!(self.nb_write(words[0]))?;
-                let cells = core::cell::Cell::from_mut(words).as_slice_of_cells();
-
-                for rw in cells.windows(2) {
-                    let r = &rw[0];
-                    let w = &rw[1];
-
-                    nb::block!(self.nb_write(w.get()))?;
-                    r.set(nb::block!(self.nb_read())?);
-                }
-                *words.last_mut().unwrap() = nb::block!(self.nb_read())?;
-                Ok(())
-            }
-            fn flush(&mut self) -> Result<(), Self::Error> {
-                // stop receiving data
-                self.set_tx_only();
-                // wait for tx fifo to be drained by the peripheral
-                while !self.spi.sr().read().ftlvl().is_empty() { core::hint::spin_loop() };
-                // drain rx fifo
-                Ok(while match self.nb_read::<u8>() {
-                    Ok(_) => true,
-                    Err(nb::Error::WouldBlock) => false,
-                    Err(nb::Error::Other(e)) => return Err(e)
-                } { core::hint::spin_loop() })
-            }
-        }
-
-        impl<PINS> embedded_hal_old::spi::FullDuplex<u8> for Spi<$SPIX, PINS> {
-            type Error = Error;
-
-            fn read(&mut self) -> nb::Result<u8, Error> {
-                self.nb_read()
-            }
-
-            fn send(&mut self, byte: u8) -> nb::Result<(), Error> {
-                self.nb_write(byte)
-            }
-        }
-        unsafe impl<Pin> TargetAddress<MemoryToPeripheral> for Spi<$SPIX, Pin> {
+        unsafe impl<PINS> TargetAddress<MemoryToPeripheral> for Spi<$SPIX, PINS> {
             #[inline(always)]
             fn address(&self) -> u32 {
                 // unsafe: only the Tx part accesses the Tx register
                 unsafe { &*<$SPIX>::ptr() }.dr() as *const _ as u32
             }
-
             type MemSize = u8;
-
             const REQUEST_LINE: Option<u8> = Some($mux as u8);
         }
-
-
-        impl<PINS> embedded_hal_old::blocking::spi::transfer::Default<u8> for Spi<$SPIX, PINS> {}
-
-        impl<PINS> embedded_hal_old::blocking::spi::write::Default<u8> for Spi<$SPIX, PINS> {}
     }
+}
+
+impl<SPI: Instance, PINS> Spi<SPI, PINS> {
+    pub fn release(self) -> (SPI, PINS) {
+        (self.spi, self.pins)
+    }
+
+    pub fn enable_tx_dma(self) -> Spi<SPI, PINS> {
+        self.spi
+            .registers()
+            .cr2()
+            .modify(|_, w| w.txdmaen().set_bit());
+        Spi {
+            spi: self.spi,
+            pins: self.pins,
+        }
+    }
+
+    #[inline]
+    fn nb_read<W: FrameSize>(&mut self) -> nb::Result<W, Error> {
+        let sr = self.spi.registers().sr().read();
+        Err(if sr.ovr().bit_is_set() {
+            nb::Error::Other(Error::Overrun)
+        } else if sr.modf().bit_is_set() {
+            nb::Error::Other(Error::ModeFault)
+        } else if sr.crcerr().bit_is_set() {
+            nb::Error::Other(Error::Crc)
+        } else if sr.rxne().bit_is_set() {
+            return Ok(self.read_unchecked());
+        } else {
+            nb::Error::WouldBlock
+        })
+    }
+    #[inline]
+    fn nb_write<W: FrameSize>(&mut self, word: W) -> nb::Result<(), Error> {
+        let sr = self.spi.registers().sr().read();
+        Err(if sr.ovr().bit_is_set() {
+            nb::Error::Other(Error::Overrun)
+        } else if sr.modf().bit_is_set() {
+            nb::Error::Other(Error::ModeFault)
+        } else if sr.crcerr().bit_is_set() {
+            nb::Error::Other(Error::Crc)
+        } else if sr.txe().bit_is_set() {
+            self.write_unchecked(word);
+            return Ok(());
+        } else {
+            nb::Error::WouldBlock
+        })
+    }
+    #[inline]
+    fn nb_read_no_err<W: FrameSize>(&mut self) -> nb::Result<W, core::convert::Infallible> {
+        if self.spi.registers().sr().read().rxne().bit_is_set() {
+            Ok(self.read_unchecked())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+    #[inline]
+    fn read_unchecked<W: FrameSize>(&mut self) -> W {
+        // NOTE(read_volatile) read only 1 byte (the svd2rust API only allows
+        // reading a half-word)
+        unsafe { ptr::read_volatile(&self.spi.registers().dr() as *const _ as *const W) }
+    }
+    #[inline]
+    fn write_unchecked<W: FrameSize>(&mut self, word: W) {
+        let dr = self.spi.registers().dr().as_ptr() as *mut W;
+        unsafe { ptr::write_volatile(dr, word) };
+    }
+    #[inline]
+    pub fn set_tx_only(&mut self) {
+        self.spi
+            .registers()
+            .cr1()
+            .modify(|_, w| w.bidimode().set_bit().bidioe().set_bit());
+    }
+    #[inline]
+    pub fn set_bidi(&mut self) {
+        self.spi
+            .registers()
+            .cr1()
+            .modify(|_, w| w.bidimode().clear_bit().bidioe().clear_bit());
+    }
+    fn tx_fifo_cap(&self) -> u8 {
+        match self.spi.registers().sr().read().ftlvl().bits() {
+            0 => 4,
+            1 => 3,
+            2 => 2,
+            _ => 0,
+        }
+    }
+    fn flush_inner(&mut self) -> Result<(), Error> {
+        // stop receiving data
+        self.set_tx_only();
+        self.spi.registers().cr2().modify(|_, w| w.frxth().set_bit());
+        // drain rx fifo
+        while match self.nb_read::<u8>() {
+            Ok(_) => true,
+            Err(nb::Error::WouldBlock) => false,
+            Err(nb::Error::Other(e)) => return Err(e),
+        } {
+            core::hint::spin_loop()
+        }
+        // wait for idle
+        Ok(while self.spi.registers().sr().read().bsy().bit() {
+            core::hint::spin_loop()
+        })
+    }
+}
+
+fn setup_spi_regs(regs: &spi1::RegisterBlock, spi_freq: u32, bus_freq: u32, mode: Mode) {
+    // disable SS output
+    regs.cr2().write(|w| w.ssoe().clear_bit());
+
+    let br = match bus_freq / spi_freq {
+        0 => unreachable!(),
+        1..=2 => 0b000,
+        3..=5 => 0b001,
+        6..=11 => 0b010,
+        12..=23 => 0b011,
+        24..=47 => 0b100,
+        48..=95 => 0b101,
+        96..=191 => 0b110,
+        _ => 0b111,
+    };
+
+    regs.cr2()
+        .write(|w| unsafe { w.frxth().set_bit().ds().bits(0b111).ssoe().clear_bit() });
+
+    regs.cr1().write(|w| unsafe {
+        w.cpha()
+            .bit(mode.phase == Phase::CaptureOnSecondTransition)
+            .cpol()
+            .bit(mode.polarity == Polarity::IdleHigh)
+            .mstr()
+            .set_bit()
+            .br()
+            .bits(br)
+            .lsbfirst()
+            .clear_bit()
+            .ssm()
+            .set_bit()
+            .ssi()
+            .set_bit()
+            .rxonly()
+            .clear_bit()
+            .bidimode()
+            .clear_bit()
+            .ssi()
+            .set_bit()
+            .spe()
+            .set_bit()
+    });
+}
+
+impl<SPI: Instance> SpiExt<SPI> for SPI {
+    fn spi<PINS, T>(self, pins: PINS, mode: Mode, freq: T, rcc: &mut Rcc) -> Spi<SPI, PINS>
+    where
+        PINS: Pins<SPI>,
+        T: Into<Hertz>,
+    {
+        Self::enable(rcc);
+        Self::reset(rcc);
+
+        let spi_freq = freq.into().raw();
+        let bus_freq = SPI::get_frequency(&rcc.clocks).raw();
+        setup_spi_regs(self.registers(), spi_freq, bus_freq, mode);
+
+        Spi { spi: self, pins }
+    }
+}
+
+impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::ErrorType for Spi<SPI, PINS> {
+    type Error = Error;
+}
+
+impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u8> for Spi<SPI, PINS> {
+    fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        let len = words.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        // flush data from previous operations, otherwise we'd get unwanted data
+        self.flush_inner()?;
+        // FIFO threshold to 16 bits
+        self.spi
+            .registers()
+            .cr2()
+            .modify(|_, w| w.frxth().clear_bit());
+        self.set_bidi();
+
+        let half_len = len / 2;
+        let pair_left = len % 2;
+
+        // prefill write fifo so that the clock doen't stop while fetch the read byte
+        let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, half_len);
+        for _ in 0..prefill {
+            nb::block!(self.nb_write(0u16))?;
+        }
+
+        for r in words.chunks_exact_mut(2).take(half_len - prefill) {
+            let r_two: u16 = nb::block!(self.nb_read_no_err()).unwrap();
+            nb::block!(self.nb_write(0u16))?;
+            // safety: chunks have exact length of 2
+            unsafe {
+                *r.as_mut_ptr().cast() = r_two.to_le_bytes();
+            }
+        }
+
+        let odd_idx = len.saturating_sub(2 * prefill + pair_left);
+        // FIFO threshold to 8 bits
+        self.spi.registers().cr2().modify(|_, w| w.frxth().set_bit());
+        if pair_left == 1 {
+            nb::block!(self.nb_write(0u8))?;
+            words[odd_idx] = nb::block!(self.nb_read_no_err()).unwrap();
+        }
+
+        Ok(for r in words[odd_idx + pair_left..].iter_mut() {
+            *r = nb::block!(self.nb_read())?;
+        })
+    }
+
+    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        self.set_tx_only();
+        Ok(for w in words {
+            nb::block!(self.nb_write(*w))?
+        })
+    }
+
+    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+        if read.len() == 0 {
+            return self.write(write);
+        } else if write.len() == 0 {
+            return self.read(read);
+        }
+
+        self.flush_inner()?;
+        self.set_bidi();
+        let common_len = core::cmp::min(read.len(), write.len());
+        let half_len = common_len / 2;
+        let pair_left = common_len % 2;
+
+        // write two bytes at once
+        let mut write_iter = write.chunks_exact(2).map(|two|
+                    // safety: chunks_exact guarantees that chunks have 2 elements
+                    // second byte in send queue goes to the top of the 16-bit data register for
+                    // packing
+                    u16::from_le_bytes(unsafe { *two.as_ptr().cast() }));
+
+        // FIFO threshold to 16 bits
+        self.spi
+            .registers()
+            .cr2()
+            .modify(|_, w| w.frxth().clear_bit());
+
+        // same prefill as in read, this time with actual data
+        let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, half_len);
+        for b in write_iter.by_ref().take(prefill) {
+            nb::block!(self.nb_write(b))?;
+        }
+
+        // write ahead of reading
+        let zipped = read
+            .chunks_exact_mut(2)
+            .zip(write_iter)
+            .take(half_len - prefill);
+        for (r, w) in zipped {
+            let r_two: u16 = nb::block!(self.nb_read_no_err()).unwrap();
+            nb::block!(self.nb_write(w))?;
+            // same as above, length is checked by chunks_exact
+            unsafe {
+                *r.as_mut_ptr().cast() = r_two.to_le_bytes();
+            }
+        }
+
+        // FIFO threshold to 8 bits
+        self.spi.registers().cr2().modify(|_, w| w.frxth().set_bit());
+
+        if pair_left == 1 {
+            let write_idx = common_len - 1;
+            if prefill == 0 {
+                nb::block!(self.nb_write(write[write_idx]))?;
+                read[write_idx - 2 * prefill] = nb::block!(self.nb_read_no_err()).unwrap();
+            } else {
+                // there's already data in the fifo, so read that before writing more
+                read[write_idx - 2 * prefill] = nb::block!(self.nb_read_no_err()).unwrap();
+                nb::block!(self.nb_write(write[write_idx]))?;
+            }
+        }
+
+        // read words left in the fifo
+        for r in read[common_len - 2 * prefill..common_len].iter_mut() {
+            *r = nb::block!(self.nb_read())?
+        }
+
+        if read.len() > common_len {
+            self.read(&mut read[common_len..])
+        } else {
+            self.write(&write[common_len..])
+        }
+    }
+    fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        let len = words.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        self.flush_inner()?;
+        self.set_bidi();
+        self.spi
+            .registers()
+            .cr2()
+            .modify(|_, w| w.frxth().clear_bit());
+        let half_len = len / 2;
+        let pair_left = len % 2;
+
+        let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, half_len);
+        let words_alias: &mut [[u8; 2]] = unsafe {
+            let ptr = words.as_mut_ptr();
+            core::slice::from_raw_parts_mut(ptr as *mut [u8; 2], half_len)
+        };
+
+        for b in words_alias.into_iter().take(prefill as usize) {
+            nb::block!(self.nb_write(u16::from_le_bytes(*b)))?;
+        }
+
+        // data is in fifo isn't zero as long as words.len() > 1 so read-then-write is fine
+        for i in 0..words_alias.len() - prefill {
+            let read: u16 = nb::block!(self.nb_read_no_err()).unwrap();
+            words_alias[i] = read.to_le_bytes();
+            let write = u16::from_le_bytes(words_alias[i + prefill]);
+            nb::block!(self.nb_write(write))?;
+        }
+        self.spi.registers().cr2().modify(|_, w| w.frxth().set_bit());
+
+        if pair_left == 1 {
+            let read_idx = len - 2 * prefill - 1;
+            if prefill == 0 {
+                nb::block!(self.nb_write(*words.last().unwrap()))?;
+                words[read_idx] = nb::block!(self.nb_read_no_err()).unwrap();
+            } else {
+                words[read_idx] = nb::block!(self.nb_read_no_err()).unwrap();
+                nb::block!(self.nb_write(*words.last().unwrap()))?;
+            }
+        }
+
+        // read words left in the fifo
+        Ok(for r in words.iter_mut().skip(len - 2 * prefill) {
+            *r = nb::block!(self.nb_read())?;
+        })
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.flush_inner()
+    }
+}
+impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u16> for Spi<SPI, PINS> {
+    fn read(&mut self, words: &mut [u16]) -> Result<(), Self::Error> {
+        let len = words.len();
+        if len == 0 {
+            return Ok(());
+        }
+        // flush data from previous operations, otherwise we'd get unwanted data
+        self.flush_inner()?;
+        // FIFO threshold to 16 bits
+        self.spi
+            .registers()
+            .cr2()
+            .modify(|_, w| w.frxth().clear_bit());
+        self.set_bidi();
+        // prefill write fifo so that the clock doen't stop while fetch the read byte
+        let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, len);
+        for _ in 0..prefill {
+            nb::block!(self.nb_write(0u16))?;
+        }
+
+        for w in &mut words[..len - prefill] {
+            *w = nb::block!(self.nb_read_no_err()).unwrap();
+            nb::block!(self.nb_write(0u16))?;
+        }
+        Ok(for w in &mut words[len - prefill..] {
+            *w = nb::block!(self.nb_read())?;
+        })
+    }
+    fn write(&mut self, words: &[u16]) -> Result<(), Self::Error> {
+        self.set_tx_only();
+        Ok(for w in words {
+            nb::block!(self.nb_write(*w))?
+        })
+    }
+    fn transfer(&mut self, read: &mut [u16], write: &[u16]) -> Result<(), Self::Error> {
+        if read.len() == 0 {
+            return self.write(write);
+        } else if write.len() == 0 {
+            return self.read(read);
+        }
+
+        self.flush_inner()?;
+        // FIFO threshold to 16 bits
+        self.spi
+            .registers()
+            .cr2()
+            .modify(|_, w| w.frxth().clear_bit());
+        self.set_bidi();
+        let common_len = core::cmp::min(read.len(), write.len());
+        // same prefill as in read, this time with actual data
+        let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, common_len);
+
+        let mut write_iter = write.into_iter();
+        for w in write_iter.by_ref().take(prefill) {
+            nb::block!(self.nb_write(*w))?;
+        }
+
+        let zipped = read.into_iter().zip(write_iter).take(common_len - prefill);
+        for (r, w) in zipped {
+            *r = nb::block!(self.nb_read_no_err()).unwrap();
+            nb::block!(self.nb_write(*w))?;
+        }
+
+        for r in &mut read[common_len - prefill..common_len] {
+            *r = nb::block!(self.nb_read())?
+        }
+
+        if read.len() > common_len {
+            self.read(&mut read[common_len..])
+        } else {
+            self.write(&write[common_len..])
+        }
+    }
+    fn transfer_in_place(&mut self, words: &mut [u16]) -> Result<(), Self::Error> {
+        let len = words.len();
+        if len == 0 {
+            return Ok(());
+        }
+
+        self.flush_inner()?;
+        self.set_bidi();
+        self.spi
+            .registers()
+            .cr2()
+            .modify(|_, w| w.frxth().clear_bit());
+        let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, len);
+
+        for w in &words[..prefill] {
+            nb::block!(self.nb_write(*w))?;
+        }
+
+        for read_idx in 0..len - prefill {
+            let write_idx = read_idx + prefill;
+            words[read_idx] = nb::block!(self.nb_read_no_err()).unwrap();
+            nb::block!(self.nb_write(words[write_idx]))?;
+        }
+
+        Ok(for r in &mut words[len - prefill..] {
+            *r = nb::block!(self.nb_read())?;
+        })
+    }
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.flush_inner()
+    }
+}
+
+impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal_old::spi::FullDuplex<u8> for Spi<SPI, PINS> {
+    type Error = Error;
+
+    fn read(&mut self) -> nb::Result<u8, Error> {
+        self.nb_read()
+    }
+
+    fn send(&mut self, byte: u8) -> nb::Result<(), Error> {
+        self.nb_write(byte)
+    }
+}
+
+impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal_old::blocking::spi::transfer::Default<u8>
+    for Spi<SPI, PINS>
+{
+}
+
+impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal_old::blocking::spi::write::Default<u8>
+    for Spi<SPI, PINS>
+{
 }
 
 spi!(

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -12,7 +12,7 @@ use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
 use crate::stm32::SPI4;
 use crate::stm32::{spi1, SPI1, SPI2, SPI3};
 use crate::time::Hertz;
-use core::{ptr, ops::Deref};
+use core::{ops::Deref, ptr};
 
 use embedded_hal::spi::ErrorKind;
 pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
@@ -86,11 +86,7 @@ impl FrameSize for u16 {
 }
 
 pub trait Instance:
-    crate::Sealed
-    + Deref<Target = spi1::RegisterBlock>
-    + Enable
-    + Reset
-    + GetBusFreq
+    crate::Sealed + Deref<Target = spi1::RegisterBlock> + Enable + Reset + GetBusFreq
 {
     const DMA_MUX_RESOURCE: DmaMuxResources;
 }
@@ -140,9 +136,7 @@ impl<SPI: Instance, PINS> Spi<SPI, PINS> {
     }
 
     pub fn enable_tx_dma(self) -> Spi<SPI, PINS> {
-        self.spi
-            .cr2()
-            .modify(|_, w| w.txdmaen().set_bit());
+        self.spi.cr2().modify(|_, w| w.txdmaen().set_bit());
         Spi {
             spi: self.spi,
             pins: self.pins,
@@ -316,9 +310,7 @@ impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u8> for Spi<SPI, 
         // flush data from previous operations, otherwise we'd get unwanted data
         self.flush_inner()?;
         // FIFO threshold to 16 bits
-        self.spi
-            .cr2()
-            .modify(|_, w| w.frxth().clear_bit());
+        self.spi.cr2().modify(|_, w| w.frxth().clear_bit());
         self.set_bidi();
 
         let half_len = len / 2;
@@ -382,9 +374,7 @@ impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u8> for Spi<SPI, 
                     u16::from_le_bytes(unsafe { *two.as_ptr().cast() }));
 
         // FIFO threshold to 16 bits
-        self.spi
-            .cr2()
-            .modify(|_, w| w.frxth().clear_bit());
+        self.spi.cr2().modify(|_, w| w.frxth().clear_bit());
 
         // same prefill as in read, this time with actual data
         let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, half_len);
@@ -440,9 +430,7 @@ impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u8> for Spi<SPI, 
 
         self.flush_inner()?;
         self.set_bidi();
-        self.spi
-            .cr2()
-            .modify(|_, w| w.frxth().clear_bit());
+        self.spi.cr2().modify(|_, w| w.frxth().clear_bit());
         let half_len = len / 2;
         let pair_left = len % 2;
 
@@ -495,9 +483,7 @@ impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u16> for Spi<SPI,
         // flush data from previous operations, otherwise we'd get unwanted data
         self.flush_inner()?;
         // FIFO threshold to 16 bits
-        self.spi
-            .cr2()
-            .modify(|_, w| w.frxth().clear_bit());
+        self.spi.cr2().modify(|_, w| w.frxth().clear_bit());
         self.set_bidi();
         // prefill write fifo so that the clock doen't stop while fetch the read byte
         let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, len);
@@ -530,9 +516,7 @@ impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u16> for Spi<SPI,
 
         self.flush_inner()?;
         // FIFO threshold to 16 bits
-        self.spi
-            .cr2()
-            .modify(|_, w| w.frxth().clear_bit());
+        self.spi.cr2().modify(|_, w| w.frxth().clear_bit());
         self.set_bidi();
         let common_len = core::cmp::min(read.len(), write.len());
         // same prefill as in read, this time with actual data
@@ -567,9 +551,7 @@ impl<SPI: Instance, PINS: Pins<SPI>> embedded_hal::spi::SpiBus<u16> for Spi<SPI,
 
         self.flush_inner()?;
         self.set_bidi();
-        self.spi
-            .cr2()
-            .modify(|_, w| w.frxth().clear_bit());
+        self.spi.cr2().modify(|_, w| w.frxth().clear_bit());
         let prefill = core::cmp::min(self.tx_fifo_cap() as usize / 2, len);
 
         for w in &words[..prefill] {


### PR DESCRIPTION
I had done some work on moving code out of the macros last year, but it kind of got stuck waiting for the hal-1 pr being merged, recently i saw that there was ongoing work on de-macroing other peripherals and though I'd try getting this upstreamed.

It also contains some SPI driver optimizations that make it do blocking mode fairly fast (1/4 to 1/2 of the CPU clock), though i haven't checked how they impact code size