### PR TITLE
Fix SysCfg hardfault, Add I2C Fast Mode Plus enable method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ embedded-sdmmc = "0.3.0"
 usb-device = { version = "0.3.2", features = ["defmt"] }
 usbd-serial = "0.2.2"
 rand = { version = "0.9", default-features = false }
+as5600 = "0.8.0"
 
 #TODO: Separate feature sets
 [features]
@@ -84,9 +85,23 @@ usb = ["dep:stm32-usbd"]
 stm32g431 = ["stm32g4/stm32g431", "cat2"]
 stm32g441 = ["stm32g4/stm32g441", "cat2"]
 stm32g473 = ["stm32g4/stm32g473", "cat3", "adc3", "adc4", "adc5"]
-stm32g474 = ["stm32g4/stm32g474", "cat3", "adc3", "adc4", "adc5", "stm32-hrtim/stm32g474"]
+stm32g474 = [
+    "stm32g4/stm32g474",
+    "cat3",
+    "adc3",
+    "adc4",
+    "adc5",
+    "stm32-hrtim/stm32g474",
+]
 stm32g483 = ["stm32g4/stm32g483", "cat3", "adc3", "adc4", "adc5"]
-stm32g484 = ["stm32g4/stm32g484", "cat3", "adc3", "adc4", "adc5", "stm32-hrtim/stm32g484"]
+stm32g484 = [
+    "stm32g4/stm32g484",
+    "cat3",
+    "adc3",
+    "adc4",
+    "adc5",
+    "stm32-hrtim/stm32g484",
+]
 stm32g491 = ["stm32g4/stm32g491", "cat4", "adc3"]
 stm32g4a1 = ["stm32g4/stm32g4a1", "cat4", "adc3"]
 
@@ -108,7 +123,7 @@ defmt = [
     "embedded-hal/defmt-03",
     "embedded-io/defmt-03",
     "embedded-test/defmt",
-    "stm32-hrtim?/defmt"
+    "stm32-hrtim?/defmt",
 ]
 cordic = ["dep:fixed"]
 adc3 = []

--- a/Embed.toml
+++ b/Embed.toml
@@ -1,0 +1,2 @@
+[default.rtt]
+enabled = true

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -52,17 +52,9 @@ fn main() -> ! {
 
     let mut dp = stm32::Peripherals::take().expect("cannot take peripherals");
 
-    // Workaround for RTT when using wfi instruction
-    // Enable the debug sleep bits in DBGMCU,
-    // then enable DMA peripheral clock in AHB1ENR
-    dp.DBGMCU.cr().modify(|_, w| {
-        w.dbg_sleep().set_bit();
-        w.dbg_stop().set_bit();
-        w.dbg_standby().set_bit()
-    });
-
     let mut rcc = dp.RCC.constrain();
 
+    // Workaround for RTT when using wfi instruction
     // Enable an AHB peripheral clock for debug probe with wfi
     rcc.ahb1enr().modify(|_, w| w.dma1en().set_bit());
 

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -5,8 +5,7 @@ use stm32g4xx_hal::{
     //delay::{DelayExt, SYSTDelayExt},
     gpio::{self, ExtiPin, GpioExt, Input, SignalEdge},
     rcc::RccExt,
-    stm32,
-    stm32::{interrupt, Interrupt},
+    stm32::{self, interrupt, Interrupt},
     syscfg::SysCfgExt,
 };
 
@@ -52,7 +51,21 @@ fn main() -> ! {
     utils::logger::init();
 
     let mut dp = stm32::Peripherals::take().expect("cannot take peripherals");
+
+    // Workaround for RTT when using wfi instruction
+    // Enable the debug sleep bits in DBGMCU,
+    // then enable DMA peripheral clock in AHB1ENR
+    dp.DBGMCU.cr().modify(|_, w| {
+        w.dbg_sleep().set_bit();
+        w.dbg_stop().set_bit();
+        w.dbg_standby().set_bit()
+    });
+
     let mut rcc = dp.RCC.constrain();
+
+    // Enable an AHB peripheral clock for debug probe with wfi
+    rcc.ahb1enr().modify(|_, w| w.dma1en().set_bit());
+
     let mut syscfg = dp.SYSCFG.constrain(&mut rcc);
 
     println!("Led Init");
@@ -80,7 +93,7 @@ fn main() -> ! {
 
     println!("Start Loop");
     loop {
-        //wfi();
+        cortex_m::asm::wfi();
         println!("Check");
 
         if G_LED_ON.load(Ordering::Relaxed) {

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -53,7 +53,7 @@ fn main() -> ! {
 
     let mut dp = stm32::Peripherals::take().expect("cannot take peripherals");
     let mut rcc = dp.RCC.constrain();
-    let mut syscfg = dp.SYSCFG.constrain();
+    let mut syscfg = dp.SYSCFG.constrain(&mut rcc);
 
     println!("Led Init");
     // Configure PA5 pin to blink LED
@@ -80,7 +80,7 @@ fn main() -> ! {
 
     println!("Start Loop");
     loop {
-        wfi();
+        //wfi();
         println!("Check");
 
         if G_LED_ON.load(Ordering::Relaxed) {

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -11,7 +11,7 @@ use stm32g4xx_hal::{
 
 use core::cell::RefCell;
 use core::sync::atomic::{AtomicBool, Ordering};
-use cortex_m::{asm::wfi, interrupt::Mutex};
+use cortex_m::interrupt::Mutex;
 use cortex_m_rt::entry;
 
 type ButtonPin = gpio::PC13<Input>;

--- a/examples/i2c-fmp-as5600.rs
+++ b/examples/i2c-fmp-as5600.rs
@@ -1,0 +1,92 @@
+//! I2C Fast Mode Plus example with an AS5600 magnetic angle sensor.
+//!
+//! This example expects the AS5600 to be connected to the I2C bus on PB7 (SDA) and PA15 (SCL),
+//! and a 24MHz HSE oscillator to configure the PLL for 168MHz system clock.
+//!
+//! The I2C bus is configured with Fast Mode Plus (FMP) enabled in SysCfg, and a 1MHz I2C clock rate.
+//!
+//! ```DEFMT_LOG=debug cargo run --release --example rand --features stm32g431,defmt -- --chip STM32G431KBTx```
+
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use fugit::HertzU32 as Hertz;
+use hal::prelude::*;
+use hal::rcc::SysClockSrc;
+use hal::stm32;
+use hal::time::RateExtU32;
+use stm32g4xx_hal as hal;
+use stm32g4xx_hal::syscfg::SysCfgExt;
+
+use as5600::As5600;
+use cortex_m_rt::entry;
+
+#[macro_use]
+mod utils;
+use utils::logger::error;
+use utils::logger::info;
+
+#[entry]
+fn main() -> ! {
+    utils::logger::init();
+
+    let dp = stm32::Peripherals::take().expect("cannot take peripherals");
+    //let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
+
+    let pwr_cfg = dp
+        .PWR
+        .constrain()
+        .vos(stm32g4xx_hal::pwr::VoltageScale::Range1 { enable_boost: true })
+        .freeze();
+
+    let pll_cfg = hal::rcc::PllConfig {
+        mux: hal::rcc::PllSrc::HSE(Hertz::MHz(24)),
+        m: hal::rcc::PllMDiv::DIV_2,
+        n: hal::rcc::PllNMul::MUL_28,
+        r: Some(hal::rcc::PllRDiv::DIV_2),
+        q: None,
+        p: None,
+    };
+
+    info!("Configuring PLL");
+    let rcc_cfg = hal::rcc::Config::new(SysClockSrc::PLL)
+        .boost(true)
+        .pll_cfg(pll_cfg);
+
+    let mut rcc = dp.RCC.freeze(rcc_cfg, pwr_cfg);
+    info!("System clock frequency: {}", rcc.clocks.sys_clk.to_Hz());
+
+    let gpioa = dp.GPIOA.split(&mut rcc);
+    let gpiob = dp.GPIOB.split(&mut rcc);
+
+    let sda = gpiob.pb7.into_alternate_open_drain();
+    let scl = gpioa.pa15.into_alternate_open_drain();
+
+    let mut syscfg = dp.SYSCFG.constrain(&mut rcc);
+
+    // Enable Fast Mode Plus for I2C1
+    syscfg.i2c_fmp_enable::<1>(true);
+
+    // Configure I2C for 1MHz
+    let i2c = dp.I2C1.i2c(sda, scl, 1.MHz(), &mut rcc);
+
+    let mut as5600 = As5600::new(i2c);
+
+    loop {
+        match as5600.angle() {
+            Ok(angle) => {
+                // Convert angle to degrees
+                let angle_degrees = angle as f32 * 360.0 / 4096.0;
+                info!("Angle: {}°", angle_degrees);
+            }
+            Err(e) => match e {
+                as5600::error::Error::Communication(_) => error!("I2C communication error"),
+                as5600::error::Error::Status(_error) => error!("AS5600 status error"),
+                as5600::error::Error::Configuration(_error) => error!("AS5600 configuration error"),
+                _ => error!("Other AS5600 error"),
+            },
+        }
+    }
+}

--- a/examples/i2c-fmp-as5600.rs
+++ b/examples/i2c-fmp-as5600.rs
@@ -5,7 +5,7 @@
 //!
 //! The I2C bus is configured with Fast Mode Plus (FMP) enabled in SysCfg, and a 1MHz I2C clock rate.
 //!
-//! ```DEFMT_LOG=debug cargo run --release --example rand --features stm32g431,defmt -- --chip STM32G431KBTx```
+//! ```DEFMT_LOG=debug cargo run --release --example i2c-fmp-as5600 --features stm32g431,defmt -- --chip STM32G431KBTx```
 
 #![deny(warnings)]
 #![deny(unsafe_code)]

--- a/src/syscfg.rs
+++ b/src/syscfg.rs
@@ -27,3 +27,22 @@ impl Deref for SysCfg {
         &self.0
     }
 }
+
+impl SysCfg {
+    /// Enable/disable I2C fast mode plus on the I2C bus index provided as a const generic parameter.
+    ///
+    /// Pins that are configured as I2C alternate functions will be configured as fast mode plus.
+    /// The alternate function mode of the pin must be set before FMP is enabled in SysCfg.
+    ///
+    /// When FM+ mode is activated on a pin, the GPIO speed configuration (OSPEEDR) is is ignored and overridden.
+    ///
+    pub fn i2c_fmp_enable<const BUS: u8>(&mut self, en: bool) {
+        match BUS {
+            1 => (*self).cfgr1().modify(|_, w| w.i2c1_fmp().bit(en)),
+            2 => (*self).cfgr1().modify(|_, w| w.i2c2_fmp().bit(en)),
+            3 => (*self).cfgr1().modify(|_, w| w.i2c3_fmp().bit(en)),
+            4 => (*self).cfgr1().modify(|_, w| w.i2c4_fmp().bit(en)),
+            _ => panic!("Invalid I2C bus"),
+        };
+    }
+}

--- a/src/syscfg.rs
+++ b/src/syscfg.rs
@@ -1,4 +1,4 @@
-use crate::rcc::Rcc;
+use crate::rcc::{Enable, Rcc, Reset};
 use crate::stm32::SYSCFG;
 use core::ops::Deref;
 
@@ -10,8 +10,8 @@ pub trait SysCfgExt {
 
 impl SysCfgExt for SYSCFG {
     fn constrain(self, rcc: &mut Rcc) -> SysCfg {
-        // Enable SYSCFG peripheral clock in APB2ENR register
-        rcc.apb2enr().modify(|_, w| w.syscfgen().set_bit());
+        SYSCFG::enable(rcc);
+        SYSCFG::reset(rcc);
 
         SysCfg(self)
     }

--- a/src/syscfg.rs
+++ b/src/syscfg.rs
@@ -34,7 +34,7 @@ impl SysCfg {
     /// Pins that are configured as I2C alternate functions will be configured as fast mode plus.
     /// The alternate function mode of the pin must be set before FMP is enabled in SysCfg.
     ///
-    /// When FM+ mode is activated on a pin, the GPIO speed configuration (OSPEEDR) is is ignored and overridden.
+    /// When FM+ mode is activated on a pin, the GPIO speed configuration (OSPEEDR) is ignored and overridden.
     ///
     pub fn i2c_fmp_enable<const BUS: u8>(&mut self, en: bool) {
         match BUS {


### PR DESCRIPTION
The `SysCfg` peripheral used bit banding to set the APB2 peripheral clock enable bit which fails on an assertion on a G431KBT (have not tested on other chips, but I suspect they would do the same). This takes a mutable reference to `Rcc` in `SysCfg::constrain` and uses safe accessors to enable the clock.

Updated and tested the button example which is all that uses SysCfg.

```[INFO ] Configuring PLL (stm32_foc stm32-foc/src/main.rs:132)
[INFO ] System clock frequency: 168000000 (stm32_foc stm32-foc/src/main.rs:138)
[DEBUG] Write 20007FB0 (stm32g4xx_hal stm32g4xx-hal/src/bb.rs:42)
[ERROR] panicked at /Users/fuzz/wave/stm32g4xx-hal/src/bb.rs:44:5:
assertion failed: (PERI_ADDRESS_START..=PERI_ADDRESS_END).contains(&addr) (panic_probe panic-probe-1.0.0/src/lib.rs:104)
Firmware exited unexpectedly: Multiple
Core 0
    Frame 0: HardFault_ @ 0x08006394
       /Users/fuzz/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cortex-m-rt-0.7.5/src/lib.rs:1103:1
    Frame 1: HardFault <Cause: Escalated UsageFault <Cause: Undefined instruction>> @ 0x08005ce2```