### PR TITLE
Add support for true random number generator (RNG) peripheral

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ stm32-usbd = { version = "0.7.0", optional = true }
 fixed = { version = "1.28.0", optional = true }
 embedded-io = "0.6"
 stm32-hrtim = { version = "0.1.0", optional = true }
+rand = { version = "0.9", default-features = false }
 
 [dependencies.cortex-m]
 version = "0.7.7"

--- a/examples/rand.rs
+++ b/examples/rand.rs
@@ -1,0 +1,77 @@
+//! Example of using the [`Rng`] peripheral.
+//!
+//! This example demonstrates common use cases of the [`rand::Rng`] trait using the G4 TRNG.
+//!
+//! ```DEFMT_LOG=debug cargo run --release --example rand --features stm32g431,defmt -- --chip STM32G431KBTx```
+
+#![deny(warnings)]
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+use hal::prelude::*;
+use hal::rng::RngExt;
+use hal::stm32;
+use rand::distr::Bernoulli;
+use rand::distr::Distribution;
+use rand::distr::Uniform;
+use rand::seq::IndexedRandom;
+use rand::{Rng, TryRngCore};
+use stm32g4xx_hal as hal;
+
+use cortex_m_rt::entry;
+
+#[macro_use]
+mod utils;
+
+use utils::logger::info;
+
+#[entry]
+fn main() -> ! {
+    utils::logger::init();
+
+    info!("start");
+    let dp = stm32::Peripherals::take().expect("cannot take peripherals");
+    let cp = cortex_m::Peripherals::take().expect("cannot take core peripherals");
+
+    let mut rcc = dp.RCC.constrain();
+
+    let mut delay = cp.SYST.delay(&rcc.clocks);
+
+    // Constrain and start the random number generator peripheral
+    let rng = dp.RNG.constrain(&mut rcc).start();
+
+    // Create a Uniform distribution sampler between 100 and 1000
+    let between = Uniform::try_from(100..1000).unwrap();
+
+    // Create a Bernoulli distribution sampler with a 20% probability of returning true
+    let bernoulli = Bernoulli::new(0.2).unwrap();
+
+    // A slice of values for IndexedRandom::choose
+    let slice = ["foo", "bar", "baz"];
+
+    loop {
+        let random_float = rng.unwrap_err().random::<f32>();
+        info!("Random float: {}", random_float);
+
+        let random_u8 = rng.unwrap_err().random::<u8>();
+        info!("Random u8: {}", random_u8);
+
+        let random_array: [f32; 8] = rng.unwrap_err().random();
+        info!("Random array {}", &random_array);
+
+        let random_dist = between.sample(&mut rng.unwrap_err());
+        info!("Random dist: {}", random_dist);
+
+        let random_range = rng.unwrap_err().random_range(-10..10);
+        info!("Random range: {}", random_range);
+
+        let random_choice = slice.choose(&mut rng.unwrap_err());
+        info!("Random choice: {}", random_choice);
+
+        let random_bernoulli = bernoulli.sample(&mut rng.unwrap_err());
+        info!("Random bernoulli: {}", random_bernoulli);
+
+        delay.delay_ms(1000);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod syscfg;
 pub mod time;
 pub mod timer;
 // pub mod watchdog;
+pub mod rng;
 
 #[cfg(all(
     feature = "hrtim",

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,181 @@
+//! True Random Number Generator (TRNG)
+
+use rand::TryRngCore;
+
+use crate::{rcc::Rcc, stm32::RNG};
+use core::{fmt::Formatter, marker::PhantomData};
+
+pub enum RngError {
+    NotReady,
+    SeedError,
+    ClockError,
+}
+
+impl core::fmt::Debug for RngError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            RngError::NotReady => write!(f, "RNG Not ready"),
+            RngError::SeedError => write!(f, "RNG Seed error"),
+            RngError::ClockError => write!(f, "RNG Clock error"),
+        }
+    }
+}
+
+impl core::fmt::Display for RngError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
+    }
+}
+
+/// Extension trait for the RNG register block
+pub trait RngExt {
+    fn constrain(self, rcc: &mut Rcc) -> Rng<Stopped>;
+}
+
+impl RngExt for RNG {
+    /// Constrain the RNG register block and return an Rng<Stopped>.
+    /// Enables the RNG peripheral in the AHB2ENR register.
+    /// Enables the HSI48 clock used by RNG
+    fn constrain(self, rcc: &mut Rcc) -> Rng<Stopped> {
+        // Enable RNG in AHB2ENR
+        rcc.ahb2enr().modify(|_, w| w.rngen().set_bit());
+
+        // Enable HSI48 clock used by the RNG
+        rcc.enable_hsi48();
+
+        Rng {
+            _state: PhantomData,
+        }
+    }
+}
+
+/// Type states for the RNG peripheral
+pub struct Stopped;
+pub struct Running;
+
+/// True Random Number Generator (TRNG)
+pub struct Rng<State> {
+    _state: core::marker::PhantomData<State>,
+}
+
+impl Rng<Stopped> {
+    /// Start the RNG peripheral
+    ///
+    /// Enables clock error detection and starts random number generation.
+    ///
+    /// Retrurns an [`Rng`] in the `Running` state
+    pub fn start(self) -> Rng<Running> {
+        unsafe {
+            (*RNG::ptr())
+                .cr()
+                .modify(|_, w| w.rngen().set_bit().ced().clear_bit())
+        };
+
+        Rng {
+            _state: PhantomData,
+        }
+    }
+}
+
+impl Rng<Running> {
+    /// Stop the RNG peripheral
+    ///
+    /// Returns an [`Rng`] in the `Stopped` state
+    pub fn stop(self) -> Rng<Stopped> {
+        unsafe { (*RNG::ptr()).cr().modify(|_, w| w.rngen().clear_bit()) };
+
+        Rng {
+            _state: PhantomData,
+        }
+    }
+
+    /// Check if the RNG is ready
+    #[inline(always)]
+    pub fn is_ready(&self) -> bool {
+        unsafe { (*RNG::ptr()).sr().read().drdy().bit_is_set() }
+    }
+
+    /// Check if the seed error flag is set
+    pub fn is_seed_error(&self) -> bool {
+        unsafe { (*RNG::ptr()).sr().read().seis().bit_is_set() }
+    }
+
+    /// Check if the clock error flag is set
+    pub fn is_clock_error(&self) -> bool {
+        unsafe { (*RNG::ptr()).sr().read().ceis().bit_is_set() }
+    }
+
+    /// Blocking read of a random u32 from the RNG in polling mode.
+    ///
+    /// Returns an [`RngError`] if the RNG reports an error condition.
+    /// Polls the data ready flag until a random word is ready to be read.
+    ///
+    /// For non-blocking operation use [`read_non_blocking()`]
+    pub fn read_blocking(&self) -> Result<u32, RngError> {
+        loop {
+            match self.read_non_blocking() {
+                Ok(value) => return Ok(value),
+                Err(RngError::NotReady) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Non blocking read of a random u32 from the RNG in polling mode.
+    ///
+    /// Returns an [`RngError`] if the RNG is not ready or reports an error condition.
+    ///
+    /// For blocking reads use [`read_blocking()`]
+    pub fn read_non_blocking(&self) -> Result<u32, RngError> {
+        // Read the SR register to check if there is an error condition,
+        // and if the DRDY bit is set to indicate a valid random number is available.
+        let status = unsafe { (*RNG::ptr()).sr().read() };
+
+        // Check if the seed or clock error bits are set
+        if status.seis().bit_is_set() {
+            return Err(RngError::SeedError);
+        }
+
+        if status.ceis().bit_is_set() {
+            return Err(RngError::ClockError);
+        }
+
+        if status.drdy().bit_is_set() {
+            // Data is ready. Read the DR register and return the value.
+            Ok(unsafe { (*RNG::ptr()).dr().read().bits() })
+        } else {
+            Err(RngError::NotReady)
+        }
+    }
+}
+
+/// Implement [`rand::TryRngCore`] for the RNG peripheral.
+///
+/// Since this is a fallible trait, to use this as a [`rand::RngCore`] with [`rand::Rng`],
+/// the [`unwrap_err`] method can be used for compatibility with [`rand::Rng`] but will panic on error.
+///
+/// See https://docs.rs/rand/latest/rand/trait.TryRngCore.html
+impl TryRngCore for &Rng<Running> {
+    type Error = RngError;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        self.read_blocking()
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let mut result = 0u64;
+        for _ in 0..2 {
+            result |= self.try_next_u32()? as u64;
+            result <<= 32;
+        }
+        Ok(result)
+    }
+
+    fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+        for chunk in dst.chunks_mut(size_of::<u32>()) {
+            let value = self.try_next_u32()?;
+            chunk.copy_from_slice(&value.to_ne_bytes());
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Adds `RngExt` trait to constrain and enable RNG peripheral with HSI48 clock
- Implements state machine with `Rng<Stopped>` and `Rng<Running>` types
- Provides blocking and non-blocking read methods for 32-bit random values
- Implements `TryRngCore` from `rand` for interoperability with rand traits
- Includes error handling for seed and clock error conditions