### PR TITLE
unify Instance traits

### DIFF
--- a/src/dac.rs
+++ b/src/dac.rs
@@ -7,7 +7,6 @@
 
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
-use core::ops::Deref;
 
 use crate::gpio::{Analog, PA4, PA5, PA6};
 use crate::pac;
@@ -150,13 +149,7 @@ pub trait Generator {}
 impl Generator for WaveGenerator {}
 impl Generator for SawtoothConfig {}
 
-pub trait Instance:
-    rcc::Enable
-    + rcc::Reset
-    + crate::Ptr<RB = crate::pac::dac1::RegisterBlock>
-    + Deref<Target = Self::RB>
-{
-}
+pub trait Instance: rcc::Instance + crate::Ptr<RB = crate::pac::dac1::RegisterBlock> {}
 
 pub struct DacCh<DAC: Instance, const CH: u8, const MODE_BITS: u8, ED> {
     _marker: PhantomData<(DAC, ED)>,

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -4,7 +4,7 @@ use embedded_hal::i2c::{ErrorKind, Operation, SevenBitAddress, TenBitAddress};
 use embedded_hal_old::blocking::i2c::{Read, Write, WriteRead};
 
 use crate::gpio::{self, OpenDrain};
-use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
+use crate::rcc::{BusClock, Rcc};
 #[cfg(any(
     feature = "stm32g473",
     feature = "stm32g474",
@@ -14,7 +14,7 @@ use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
 use crate::stm32::I2C4;
 use crate::stm32::{I2C1, I2C2, I2C3};
 use crate::time::Hertz;
-use core::{cmp, convert::TryInto, ops::Deref};
+use core::{cmp, convert::TryInto};
 
 /// I2C bus configuration.
 #[derive(Debug, Clone, Copy)]
@@ -197,10 +197,7 @@ macro_rules! busy_wait {
     };
 }
 
-pub trait Instance:
-    crate::Sealed + Deref<Target = i2c1::RegisterBlock> + Enable + Reset + GetBusFreq
-{
-}
+pub trait Instance: crate::rcc::Instance + crate::Ptr<RB = i2c1::RegisterBlock> {}
 
 macro_rules! i2c {
     ($I2CX:ident,
@@ -243,7 +240,7 @@ impl<I2C: Instance> I2cExt<I2C> for I2C {
 
         // Setup protocol timings
         self.timingr()
-            .write(|w| config.timing_bits(I2C::get_frequency(&rcc.clocks), w));
+            .write(|w| config.timing_bits(I2C::Bus::clock(&rcc.clocks), w));
 
         // Enable the I2C processing
         self.cr1().modify(|_, w| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,14 +117,41 @@ impl<RB, const A: usize> Sealed for Periph<RB, A> {}
 pub trait Ptr: Sealed {
     /// RegisterBlock structure
     type RB;
+    /// Pointer to the register block
+    const PTR: *const Self::RB;
     /// Return the pointer to the register block
-    fn ptr() -> *const Self::RB;
+    #[inline(always)]
+    fn ptr() -> *const Self::RB {
+        Self::PTR
+    }
 }
 
 impl<RB, const A: usize> Ptr for Periph<RB, A> {
     type RB = RB;
-    fn ptr() -> *const Self::RB {
-        Self::ptr()
+    const PTR: *const Self::RB = Self::PTR;
+}
+
+pub trait Steal: Sealed {
+    /// Steal an instance of this peripheral
+    ///
+    /// # Safety
+    ///
+    /// Ensure that the new instance of the peripheral cannot be used in a way
+    /// that may race with any existing instances, for example by only
+    /// accessing read-only or write-only registers, or by consuming the
+    /// original peripheral and using critical sections to coordinate
+    /// access between multiple new instances.
+    ///
+    /// Additionally the HAL may rely on only one
+    /// peripheral instance existing to ensure memory safety; ensure
+    /// no stolen instances are passed to such software.
+    unsafe fn steal() -> Self;
+}
+
+impl<RB, const A: usize> Steal for Periph<RB, A> {
+    #[inline(always)]
+    unsafe fn steal() -> Self {
+        Self::steal()
     }
 }
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -191,7 +191,7 @@ use crate::stm32::TIM20;
 use crate::stm32::TIM5;
 use crate::stm32::{TIM1, TIM15, TIM16, TIM17, TIM2, TIM3, TIM4, TIM8};
 
-use crate::rcc::{BusTimerClock, Enable, Rcc, Reset};
+use crate::rcc::{BusTimerClock, Enable, Rcc, RccBus, Reset};
 use crate::time::{ExtU32, Hertz, NanoSecond, RateExtU32};
 
 #[cfg(any(
@@ -1149,7 +1149,7 @@ macro_rules! tim_hal {
                 $TIMX::enable(rcc);
                 $TIMX::reset(rcc);
 
-                let clk = $TIMX::timer_clock(&rcc.clocks);
+                let clk = <$TIMX as RccBus>::Bus::timer_clock(&rcc.clocks);
 
                 let (period, prescale) = match $bits {
                     16 => calculate_frequency_16bit(clk, freq, Alignment::Left),
@@ -1188,7 +1188,7 @@ macro_rules! tim_hal {
                     $TIMX::enable(rcc);
                     $TIMX::reset(rcc);
 
-                    let clk = $TIMX::timer_clock(&rcc.clocks).raw();
+                    let clk = <$TIMX as RccBus>::Bus::timer_clock(&rcc.clocks).raw();
 
                     PwmBuilder {
                         _tim: PhantomData,
@@ -1797,7 +1797,7 @@ macro_rules! lptim_hal {
                 $TIMX::enable(rcc);
                 $TIMX::reset(rcc);
 
-                let clk = $TIMX::timer_clock(&rcc.clocks);
+                let clk = <$TIMX as RccBus>::Bus::timer_clock(&rcc.clocks);
                 let reload = clk / freq;
                 assert!(reload < 128 * (1 << 16));
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -191,7 +191,7 @@ use crate::stm32::TIM20;
 use crate::stm32::TIM5;
 use crate::stm32::{TIM1, TIM15, TIM16, TIM17, TIM2, TIM3, TIM4, TIM8};
 
-use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
+use crate::rcc::{BusTimerClock, Enable, Rcc, Reset};
 use crate::time::{ExtU32, Hertz, NanoSecond, RateExtU32};
 
 #[cfg(any(
@@ -1149,7 +1149,7 @@ macro_rules! tim_hal {
                 $TIMX::enable(rcc);
                 $TIMX::reset(rcc);
 
-                let clk = $TIMX::get_timer_frequency(&rcc.clocks);
+                let clk = $TIMX::timer_clock(&rcc.clocks);
 
                 let (period, prescale) = match $bits {
                     16 => calculate_frequency_16bit(clk, freq, Alignment::Left),
@@ -1188,7 +1188,7 @@ macro_rules! tim_hal {
                     $TIMX::enable(rcc);
                     $TIMX::reset(rcc);
 
-                    let clk = $TIMX::get_timer_frequency(&rcc.clocks).raw();
+                    let clk = $TIMX::timer_clock(&rcc.clocks).raw();
 
                     PwmBuilder {
                         _tim: PhantomData,
@@ -1797,7 +1797,7 @@ macro_rules! lptim_hal {
                 $TIMX::enable(rcc);
                 $TIMX::reset(rcc);
 
-                let clk = $TIMX::get_timer_frequency(&rcc.clocks);
+                let clk = $TIMX::timer_clock(&rcc.clocks);
                 let reload = clk / freq;
                 assert!(reload < 128 * (1 << 16));
 

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -10,7 +10,10 @@ mod enable;
 pub use clockout::*;
 pub use config::*;
 
-pub trait Instance: crate::Sealed + Enable + Reset + GetBusFreq {}
+pub trait Instance:
+    crate::Ptr + crate::Steal + Enable + Reset + RccBus<Bus: BusClock> + Deref<Target = Self::RB>
+{
+}
 
 /// HSI speed
 pub const HSI_FREQ: u32 = 16_000_000;
@@ -672,67 +675,66 @@ pub trait Reset: RccBus {
     }
 }
 
-pub trait GetBusFreq {
-    fn get_frequency(clocks: &Clocks) -> Hertz;
-    fn get_timer_frequency(clocks: &Clocks) -> Hertz {
-        Self::get_frequency(clocks)
-    }
+/// Frequency on bus that peripheral is connected in
+pub trait BusClock {
+    /// Calculates frequency depending on `Clock` state
+    fn clock(clocks: &Clocks) -> Hertz;
 }
 
-impl<T> GetBusFreq for T
-where
-    T: RccBus,
-    T::Bus: GetBusFreq,
-{
-    fn get_frequency(clocks: &Clocks) -> Hertz {
-        T::Bus::get_frequency(clocks)
-    }
-    fn get_timer_frequency(clocks: &Clocks) -> Hertz {
-        T::Bus::get_timer_frequency(clocks)
-    }
+/// Frequency on bus that timer is connected in
+pub trait BusTimerClock {
+    /// Calculates base frequency of timer depending on `Clock` state
+    fn timer_clock(clocks: &Clocks) -> Hertz;
 }
 
-impl GetBusFreq for AHB1 {
-    fn get_frequency(clocks: &Clocks) -> Hertz {
+impl BusClock for AHB1 {
+    fn clock(clocks: &Clocks) -> Hertz {
         clocks.ahb_clk
     }
 }
 
-impl GetBusFreq for AHB2 {
-    fn get_frequency(clocks: &Clocks) -> Hertz {
+impl BusClock for AHB2 {
+    fn clock(clocks: &Clocks) -> Hertz {
         clocks.ahb_clk
     }
 }
 
-impl GetBusFreq for AHB3 {
-    fn get_frequency(clocks: &Clocks) -> Hertz {
+impl BusClock for AHB3 {
+    fn clock(clocks: &Clocks) -> Hertz {
         clocks.ahb_clk
     }
 }
 
-impl GetBusFreq for APB1_1 {
-    fn get_frequency(clocks: &Clocks) -> Hertz {
+impl BusClock for APB1_1 {
+    fn clock(clocks: &Clocks) -> Hertz {
         clocks.apb1_clk
     }
-    fn get_timer_frequency(clocks: &Clocks) -> Hertz {
+}
+
+impl BusTimerClock for APB1_1 {
+    fn timer_clock(clocks: &Clocks) -> Hertz {
         clocks.apb1_tim_clk
     }
 }
 
-impl GetBusFreq for APB1_2 {
-    fn get_frequency(clocks: &Clocks) -> Hertz {
+impl BusClock for APB1_2 {
+    fn clock(clocks: &Clocks) -> Hertz {
         clocks.apb1_clk
     }
-    fn get_timer_frequency(clocks: &Clocks) -> Hertz {
+}
+impl BusTimerClock for APB1_2 {
+    fn timer_clock(clocks: &Clocks) -> Hertz {
         clocks.apb1_tim_clk
     }
 }
 
-impl GetBusFreq for APB2 {
-    fn get_frequency(clocks: &Clocks) -> Hertz {
+impl BusClock for APB2 {
+    fn clock(clocks: &Clocks) -> Hertz {
         clocks.apb2_clk
     }
-    fn get_timer_frequency(clocks: &Clocks) -> Hertz {
+}
+impl BusTimerClock for APB2 {
+    fn timer_clock(clocks: &Clocks) -> Hertz {
         clocks.apb2_tim_clk
     }
 }

--- a/src/serial/usart.rs
+++ b/src/serial/usart.rs
@@ -5,7 +5,7 @@ use crate::dma::{
     mux::DmaMuxResources, traits::TargetAddress, MemoryToPeripheral, PeripheralToMemory,
 };
 use crate::gpio::{self, OpenDrain};
-use crate::rcc::{Enable, GetBusFreq, Rcc, RccBus, Reset};
+use crate::rcc::{BusClock, Enable, Rcc, RccBus, Reset};
 use crate::stm32::*;
 
 use cortex_m::interrupt;
@@ -562,7 +562,7 @@ macro_rules! uart_lp {
                 // try SYSCLK if PCLK is not high enough. We could also select 8x oversampling
                 // instead of 16x.
 
-                let clk = <$USARTX as RccBus>::Bus::get_frequency(&rcc.clocks).raw() as u64;
+                let clk = <$USARTX as RccBus>::Bus::clock(&rcc.clocks).raw() as u64;
                 let bdr = config.baudrate.0 as u64;
                 let div = ($clk_mul * clk) / bdr;
                 if div < 16 {
@@ -710,7 +710,7 @@ macro_rules! uart_full {
                 // try SYSCLK if PCLK is not high enough. We could also select 8x oversampling
                 // instead of 16x.
 
-                let clk = <$USARTX as RccBus>::Bus::get_frequency(&rcc.clocks).raw() as u64;
+                let clk = <$USARTX as RccBus>::Bus::clock(&rcc.clocks).raw() as u64;
                 let bdr = config.baudrate.0 as u64;
                 let clk_mul = 1;
                 let div = (clk_mul * clk) / bdr;

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -291,7 +291,7 @@ impl<SPI: Instance> SpiExt<SPI> for SPI {
         Self::reset(rcc);
 
         let spi_freq = freq.into().raw();
-        let bus_freq = SPI::clock(&rcc.clocks).raw();
+        let bus_freq = SPI::Bus::clock(&rcc.clocks).raw();
         setup_spi_regs(&self, spi_freq, bus_freq, mode);
 
         Spi { spi: self, pins }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -2,7 +2,7 @@ use crate::dma::mux::DmaMuxResources;
 use crate::dma::traits::TargetAddress;
 use crate::dma::MemoryToPeripheral;
 use crate::gpio;
-use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
+use crate::rcc::{BusClock, Rcc};
 #[cfg(any(
     feature = "stm32g473",
     feature = "stm32g474",
@@ -12,7 +12,7 @@ use crate::rcc::{Enable, GetBusFreq, Rcc, Reset};
 use crate::stm32::SPI4;
 use crate::stm32::{spi1, SPI1, SPI2, SPI3};
 use crate::time::Hertz;
-use core::{ops::Deref, ptr};
+use core::ptr;
 
 use embedded_hal::spi::ErrorKind;
 pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
@@ -85,9 +85,7 @@ impl FrameSize for u16 {
     const DFF: bool = true;
 }
 
-pub trait Instance:
-    crate::Sealed + Deref<Target = spi1::RegisterBlock> + Enable + Reset + GetBusFreq
-{
+pub trait Instance: crate::rcc::Instance + crate::Ptr<RB = spi1::RegisterBlock> {
     const DMA_MUX_RESOURCE: DmaMuxResources;
 }
 
@@ -293,7 +291,7 @@ impl<SPI: Instance> SpiExt<SPI> for SPI {
         Self::reset(rcc);
 
         let spi_freq = freq.into().raw();
-        let bus_freq = SPI::get_frequency(&rcc.clocks).raw();
+        let bus_freq = SPI::clock(&rcc.clocks).raw();
         setup_spi_regs(&self, spi_freq, bus_freq, mode);
 
         Spi { spi: self, pins }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -10,7 +10,7 @@ use cortex_m::peripheral::{DCB, DWT, SYST};
 use embedded_hal_old::timer::{Cancel, CountDown as _, Periodic};
 use void::Void;
 
-use crate::rcc::{self, Clocks};
+use crate::rcc::{self, BusTimerClock, Clocks, RccBus};
 use crate::time::{Hertz, MicroSecond};
 
 /// Timer wrapper
@@ -202,7 +202,7 @@ impl Instant {
     }
 }
 
-pub trait Instance: rcc::Instance + rcc::BusTimerClock {}
+pub trait Instance: rcc::Instance + RccBus<Bus: BusTimerClock> {}
 
 impl<TIM> Timer<TIM>
 where
@@ -219,7 +219,7 @@ where
         }
 
         Self {
-            clk: TIM::timer_clock(clocks),
+            clk: TIM::Bus::timer_clock(clocks),
             tim,
         }
     }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -202,7 +202,7 @@ impl Instant {
     }
 }
 
-pub trait Instance: crate::Sealed + rcc::Enable + rcc::Reset + rcc::GetBusFreq {}
+pub trait Instance: rcc::Instance + rcc::BusTimerClock {}
 
 impl<TIM> Timer<TIM>
 where
@@ -219,7 +219,7 @@ where
         }
 
         Self {
-            clk: TIM::get_timer_frequency(clocks),
+            clk: TIM::timer_clock(clocks),
             tim,
         }
     }


### PR DESCRIPTION
[commit 1](https://github.com/stm32-rs/stm32g4xx-hal/pull/229/commits/df2c873f825880c7ebecb15c3f7024c505b46451):
* split `GetBusFreq` on `BusClock` and `BusTimerClock`
* improve  `rcc::Instance` and use it where possible

[commit 2](https://github.com/stm32-rs/stm32g4xx-hal/pull/229/commits/7575df1236ff1ff887479a228a6de88c32807a1a) (optional):
remove `BusClock` autoimplementation. I've found that sometimes it can cause implementation conflicts 